### PR TITLE
Add N.I.F.T.Y (Naked Iconoclasts Fighting The Yoke) to Yoga & Wellness

### DIFF
--- a/yoga-wellness.md
+++ b/yoga-wellness.md
@@ -1,0 +1,5 @@
+
+
+## N.I.F.T.Y (Naked Iconoclasts Fighting The Yoke)
+- **What:** Nifty (Naked Iconoclasts Fighting The Yoke) is an activist group which hosts monthly clothing-optional swims at Templeton pool. Nifty is committed to promoting non-sexual nudity and events related to non-sexual nudity in the lower mainland. Whether you're a  Wreck Beach regular, or someone that would like to try skinny dipping for the first time, a NIFTY swim is a great outing during the dreary Vancouver fall and winter. Come, enjoy some volleyball, warm up in the hot tub or sauna, and make some new friends. See the website for more details, including a discount coupon for first timers.
+- **Find it:** [niftynude.org/](https://niftynude.org/)


### PR DESCRIPTION
## New Community Submission

**Name:** N.I.F.T.Y (Naked Iconoclasts Fighting The Yoke)
**Category:** Yoga & Wellness

**Description:**
Nifty (Naked Iconoclasts Fighting The Yoke) is an activist group which hosts monthly clothing-optional swims at Templeton pool. Nifty is committed to promoting non-sexual nudity and events related to non-sexual nudity in the lower mainland. Whether you're a  Wreck Beach regular, or someone that would like to try skinny dipping for the first time, a NIFTY swim is a great outing during the dreary Vancouver fall and winter. Come, enjoy some volleyball, warm up in the hot tub or sauna, and make some new friends. See the website for more details, including a discount coupon for first timers.


**Website/Link:** https://niftynude.org/



---
*Submitted via vancouvercommunity.org*
