### PR TITLE
Add optional Cost and Availability tags to submission form

### DIFF
--- a/content/submit.njk
+++ b/content/submit.njk
@@ -47,6 +47,23 @@ permalink: /submit/
       <label class="form-label" for="submit-link">Website or Social Link</label>
       <input class="form-input" type="url" id="submit-link" name="link" placeholder="https://...">
     </div>
+    <div class="form-field">
+      <label class="form-label" for="submit-cost">Cost</label>
+      <select class="form-input" id="submit-cost" name="cost">
+        <option value="">Not sure</option>
+        <option value="Free">Free</option>
+        <option value="By Donation">By Donation</option>
+        <option value="Paid">Paid</option>
+      </select>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="submit-availability">Who can join?</label>
+      <select class="form-input" id="submit-availability" name="availability">
+        <option value="">Not sure</option>
+        <option value="Open to All">Open to All</option>
+        <option value="Membership Required">Membership Required</option>
+      </select>
+    </div>
     <button class="form-submit" type="submit">Submit</button>
     <p class="form-status" id="form-status"></p>
   </form>

--- a/workers/submit/index.js
+++ b/workers/submit/index.js
@@ -255,6 +255,8 @@ ${data.vibe ? `**Vibe/Atmosphere:** ${data.vibe}` : ''}
 ${data.link ? `**Website/Link:** ${data.link}` : ''}
 ${data.location ? `**Location:** ${data.location}` : ''}
 ${data.additional ? `**Additional Info:** ${data.additional}` : ''}
+${data.cost ? `**Cost:** ${data.cost}` : ''}
+${data.availability ? `**Who can join:** ${data.availability}` : ''}
 
 ---
 *Submitted via vancouvercommunity.org*


### PR DESCRIPTION
## Summary
- Adds two optional dropdowns to the submit page: **Cost** (Free / By Donation / Paid) and **Availability** (Open to All / Membership Required)
- Both default to "Not sure" so they don't block submission
- Values are included in the GitHub PR body when a submission comes in

## Context
Reddit feedback suggested adding tags to submissions. Cost and availability are the lowest-hanging fruit — simple dropdowns, most useful for browsing.

## Test plan
- [ ] Visit `/submit/` and verify the two new dropdowns appear after the link field
- [ ] Submit with tags selected — confirm they show in the PR body
- [ ] Submit with defaults ("Not sure") — confirm they're omitted from the PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)