### PR TITLE
Remove RASC Vancouver from astronomy-stargazing

### DIFF
--- a/content/astronomy-stargazing.md
+++ b/content/astronomy-stargazing.md
@@ -2,18 +2,13 @@
 layout: category
 tags: category
 title: "Astronomy & Stargazing"
-description: "5 astronomy groups — star parties, free observatory nights at Vanier Park, and dark-sky camping trips."
+description: "4 astronomy groups — star parties, free observatory nights at Vanier Park, and dark-sky camping trips."
 emoji: "🔭"
 group: mind-body
 order: 7
 ---
 
 # 🔭 Astronomy / Stargazing
-
-## RASC Vancouver (Royal Astronomical Society of Canada)
-- **What:** Star parties, workshops, public observing nights
-- **Where:** SFU Trottier Observatory visits
-- **Find it:** [rasc-vancouver.com](https://rasc-vancouver.com/)
 
 ## UBC Astronomy Club
 - **What:** Student club open to astronomy enthusiasts


### PR DESCRIPTION
Removes the RASC Vancouver entry from the astronomy-stargazing category page as reported in issue #20.

Also updates the group count in the page description from 5 to 4.

Generated with [Claude Code](https://claude.ai/code)