### PR TITLE
Add Vancouver Gaymers to Board Games

### DIFF
--- a/content/board-games.md
+++ b/content/board-games.md
@@ -49,3 +49,8 @@ order: 4
 - **What:** 600+ tabletop games, worth the drive. Massive selection, friendly staff
 - **Where:** Abbotsford, ~1 hour from Vancouver
 - **Find it:** [abbyboardwalk.com](https://abbyboardwalk.com/)
+
+## Vancouver Gaymers
+- **What:** Our mission is to create and enable the creation of safer spaces for 2SLGBTQIA+ people and their allies in the Greater Vancouver Area to meet and socialize.
+We aim to enable the creation of and to provide virtual and physical spaces for events for players and participants to meet and play games, and to facilitate social events for the benefit of our members.
+- **Find it:** [www.vancouvergaymers.com/](https://www.vancouvergaymers.com/)


### PR DESCRIPTION
## New Community Submission

**Name:** Vancouver Gaymers
**Category:** Board Games

**Description:**
Our mission is to create and enable the creation of safer spaces for 2SLGBTQIA+ people and their allies in the Greater Vancouver Area to meet and socialize.
We aim to enable the creation of and to provide virtual and physical spaces for events for players and participants to meet and play games, and to facilitate social events for the benefit of our members.


**Website/Link:** https://www.vancouvergaymers.com/


**Cost:** Free


---
*Submitted via vancouvercommunity.org*
