### PR TITLE
Remove Dinners with 5 Like Minded Strangers

### DIFF
--- a/content/dinner-supper-clubs.md
+++ b/content/dinner-supper-clubs.md
@@ -2,7 +2,7 @@
 layout: category
 tags: category
 title: "Dinner & Supper Clubs"
-description: "9 supper clubs pairing strangers over curated meals — home-cooked dinners, secret locations, and wine-paired pop-ups."
+description: "8 supper clubs pairing strangers over curated meals — home-cooked dinners, secret locations, and wine-paired pop-ups."
 emoji: "🍽️"
 group: social
 order: 1
@@ -13,10 +13,6 @@ order: 1
 ## DayOfUs - Dinner with Strangers
 - **What:** Weekly curated dinners — you + 5 strangers at a surprise restaurant. Algorithm-matched based on interests, casual, low-pressure
 - **Find it:** [Eventbrite](https://www.eventbrite.com/e/dinner-with-strangers-curated-dinner-meetup-in-vancouver-registration-1709285481889)
-
-## Dinners with 5 Like Minded Strangers
-- **What:** Questionnaire-matched dinner groups at trendy restaurants. Curated, similar age ranges, complementary personalities
-- **Find it:** [meetup.com/dinners-with-5-like-minded-strangers](https://meetup.com/dinners-with-5-like-minded-strangers)
 
 ## Timeleft
 - **What:** International app, weekly dinners with strangers. Algorithm-matched, launched in Vancouver May 2024


### PR DESCRIPTION
Remove "Dinners with 5 Like Minded Strangers" from the dinner & supper clubs page - no events in the last year.

Closes #26

Generated with [Claude Code](https://claude.ai/code)