### PR TITLE
Remove Well Fed by Mix & Mingle (broken link)

### DIFF
--- a/content/dinner-supper-clubs.md
+++ b/content/dinner-supper-clubs.md
@@ -30,10 +30,6 @@ order: 1
 - **What:** Home-cooked dinners with strangers. Host provides space/cooking, you pay $50, sells out fast
 - **Find it:** [Instagram @good_finds_club](https://instagram.com/good_finds_club)
 
-## Well Fed by Mix & Mingle
-- **What:** Curated social dinners at secret restaurants. 6 like-minded strangers, carefully matched
-- **Find it:** [mixandmingle.ca](https://www.mixandmingle.ca/events/well-fed-social-dinner)
-
 ## Pass the Peas
 - **What:** Food-focused social club by husband-wife duo. Community dinners, food-centric gatherings
 - **Find it:** [passthepeas.co](https://passthepeas.co/) | [Instagram](https://instagram.com/pass_thepeas)


### PR DESCRIPTION
Removes Well Fed by Mix & Mingle from the Dinner & Supper Clubs page. The URL https://www.mixandmingle.ca/events/well-fed-social-dinner returns 404 and no longer exists.

Resolves #40

Generated with [Claude Code](https://claude.ai/code)