### PR TITLE
Remove Coffee Karaoke Nights (broken link)

### DIFF
--- a/content/karaoke.md
+++ b/content/karaoke.md
@@ -10,11 +10,6 @@ order: 4
 
 # 🎤 Karaoke
 
-## Coffee Karaoke Nights
-- **What:** Karaoke + coffee (not bar scene)
-- **Where:** Downtown Vancouver
-- **Find it:** [meetup.com/vancouver-coffee-karaoke-nights-sing-sip-and-socialize](https://meetup.com/vancouver-coffee-karaoke-nights-sing-sip-and-socialize)
-
 ## Karaoke Schedule in Metro Vancouver (Facebook)
 - **What:** Community group tracking karaoke nights. Up-to-date listings across the city
 - **Find it:** [Facebook Group](https://www.facebook.com/groups/karaokeinvancouvergroup/)


### PR DESCRIPTION
Removes the Coffee Karaoke Nights group from the karaoke category as the Meetup link leads to a "group not found" error.

Resolves #22

Generated with [Claude Code](https://claude.ai/code)