### PR TITLE
Remove Vancouver Cinema & Social Club (broken link)

### DIFF
--- a/content/film-cinema.md
+++ b/content/film-cinema.md
@@ -10,10 +10,6 @@ order: 3
 
 # 🎬 Film / Cinema
 
-## Vancouver Cinema & Social Club
-- **What:** Movies plus hiking, walking tours, food, coffee. "Not just about movies"
-- **Find it:** [meetup.com/vancouver-cinema-club](https://meetup.com/vancouver-cinema-club)
-
 ## Celluloid Social Club
 - **What:** Independent film screenings
 - **Where:** ANZA Club, 3 West 8th Ave


### PR DESCRIPTION
Removes the Vancouver Cinema & Social Club entry from the Film & Cinema page. The Meetup group at meetup.com/vancouver-cinema-club returns a "Group not found" page.

Resolves #33

Generated with [Claude Code](https://claude.ai/code)