### PR TITLE
Fix category meta titles, faster toast dismiss

### DIFF
--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -2,16 +2,24 @@
 <html lang="en">
 <head>
   {% include "partials/head.njk" %}
-  <title>{% if groupCount %}{{ groupCount }} {% endif %}{{ title }} in Vancouver (2026) | {{ site.title }}</title>
-  <meta name="description" content="{{ title }} in Vancouver — {{ description }} Updated March 2026.">
-  <meta property="og:title" content="{% if groupCount %}{{ groupCount }} {% endif %}{{ title }} in Vancouver">
-  <meta property="og:description" content="{{ title }} in Vancouver — {{ description }}">
+  {%- set titleHasGroupWord = "club" in title | lower or "group" in title | lower or "space" in title | lower or "bar" in title | lower -%}
+  {%- if groupCount and titleHasGroupWord -%}
+    {%- set metaTitle = groupCount + " " + title + " in Vancouver" -%}
+  {%- elif groupCount -%}
+    {%- set metaTitle = groupCount + " " + title + " Group" + ("s" if groupCount != 1) + " in Vancouver" -%}
+  {%- else -%}
+    {%- set metaTitle = title + " in Vancouver" -%}
+  {%- endif -%}
+  <title>{{ metaTitle }} (2026) | {{ site.title }}</title>
+  <meta name="description" content="{{ description }} Updated March 2026.">
+  <meta property="og:title" content="{{ metaTitle }}">
+  <meta property="og:description" content="{{ description }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ site.url }}/{{ page.fileSlug }}/">
   <meta property="og:image" content="{{ site.url }}/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{% if groupCount %}{{ groupCount }} {% endif %}{{ title }} in Vancouver">
-  <meta name="twitter:description" content="{% if groupCount %}{{ groupCount }} {% endif %}{{ title | lower }} in Vancouver. {{ description }}">
+  <meta name="twitter:title" content="{{ metaTitle }}">
+  <meta name="twitter:description" content="{{ description }}">
   <meta name="twitter:image" content="{{ site.url }}/og-image.png">
   <link rel="canonical" href="{{ site.url }}/{{ page.fileSlug }}/">
   <script type="application/ld+json">

--- a/src/main.js
+++ b/src/main.js
@@ -332,7 +332,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function showToastThanks(toast) {
     toast.querySelector('.verify-toast-inner').innerHTML =
       '<p class="verify-toast-thanks">Thanks, that helps keep this list accurate \u2764\ufe0f</p>';
-    setTimeout(function() { dismissToast(toast); }, 3000);
+    setTimeout(function() { dismissToast(toast); }, 1200);
   }
 
   function dismissToast(toast) {


### PR DESCRIPTION
## Summary
- Smart "Group/Groups" suffix in meta titles — "6 Chess Groups in Vancouver" but "17 Run Clubs in Vancouver" (no redundant "Groups" when title already contains club/group/space/bar)
- Use frontmatter description directly in meta description (no more prepending title)
- Toast thanks message dismisses in 1.2s instead of 3s

## Test plan
- [ ] Check title tags: `1 Volunteer Group`, `17 Run Clubs`, `3 Maker Spaces`
- [ ] Click an outbound link, confirm toast → "Looks good" → thanks dismisses quickly