### PR TITLE
Cross-promo: cuento.app + runclubs.ca banners

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -114,6 +114,9 @@ permalink: /
     </div>
     {%- endfor %}
   </div>
+  <div class="homepage-promo">
+    <p>📖 I'm also building <a href="https://cuento.app?ref=vancouvercommunity" target="_blank" rel="noopener noreferrer" data-umami-event="click-cuento-promo" data-umami-event-source="homepage">Cuento</a> — get matched into a small book club in your neighbourhood. Pick your genres, get placed with 5–6 readers nearby, and meet at a local café. <a href="https://cuento.app?ref=vancouvercommunity" target="_blank" rel="noopener noreferrer" data-umami-event="click-cuento-promo-cta" data-umami-event-source="homepage">Check it out&nbsp;&rarr;</a></p>
+  </div>
   <div class="homepage-footer">
     Made by <a href="https://bollenbach.ca?ref=vancouvercommunity" target="_blank" rel="noopener noreferrer">Patrick Bollenbach</a> in Vancouver. <span id="homepage-total-views"></span>
   </div>

--- a/content/run-clubs.md
+++ b/content/run-clubs.md
@@ -10,6 +10,10 @@ order: 1
 
 # 🏃 Run Clubs
 
+<div class="category-banner">
+🏃 Looking for every run club in Canada? I also built <a href="https://runclubs.ca?ref=vancouvercommunity" target="_blank" rel="noopener" data-umami-event="click-runclubs-banner">runclubs.ca</a> — a directory of 200+ run clubs across the country.
+</div>
+
 ## Social Run Club
 - **What:** Social runs for beginner to intermediate runners. Fun runs, not competitive
 - **Find it:** [socialrunclub.com](https://www.socialrunclub.com/)

--- a/src/style.css
+++ b/src/style.css
@@ -542,6 +542,25 @@ h1.homepage-lede,
   letter-spacing: 0.01em;
 }
 
+.homepage-promo {
+  margin-top: 56px;
+  padding: 20px 24px;
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.92em;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.homepage-promo a {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.homepage-promo a:hover { color: var(--accent-hover); }
+.homepage-promo p { margin: 0; }
+
 .homepage-footer {
   margin-top: 56px;
   padding-top: 24px;


### PR DESCRIPTION
## Summary
- Adds a personal recommendation banner for cuento.app at the bottom of the homepage
- Adds a runclubs.ca banner at the top of the run clubs category page (matching the existing cuento banner on book clubs)
- Makes the builder card more minimal on mobile (hides bio, tightens padding)

## Test plan
- [ ] Check homepage — cuento promo visible above footer
- [ ] Check /run-clubs/ — runclubs.ca banner visible at top
- [ ] Check /book-clubs/ — existing cuento banner still there
- [ ] Check mobile — builder card is compact, promo still looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)