### PR TITLE
Show verify toast when clicking h2 group headings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,6 +153,9 @@ document.addEventListener('DOMContentLoaded', function() {
             h2.addEventListener('click', function(e) {
               if (e.target.tagName === 'A') return; // let anchor links work normally
               window.open(extLink.href, '_blank', 'noopener');
+              var category = window.location.pathname.replace(/^\/|\/$/g, '');
+              var groupName = h2.textContent.replace(/\s*#\s*$/, '').trim();
+              setTimeout(function() { showVerifyToast(groupName, extLink.href, category); }, 600);
             });
             break;
           }


### PR DESCRIPTION
## Summary
- Clicking an h2 group name opened the external link but skipped the verification toast
- Now triggers the same toast as clicking a "Find it" link directly

## Test plan
- [ ] Click an h2 group heading on any category page — verify the link opens AND the toast appears
- [ ] Click a "Find it" link — verify toast still works as before