### PR TITLE
Redesign sidebar logo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ New entries go **above** the `---` / `## Venues` divider if one exists, otherwis
 
 Omit optional fields entirely if not provided — don't leave blanks.
 
+Also update `_data/recentGroups.js`: add the new group to the top of the `recent` array and remove the oldest entry (keep 6 total).
+
 ### Verifying a link
 
 Check with: `curl -sL -o /dev/null -w "%{http_code}" "URL"` — run twice if first attempt times out.

--- a/_data/recentGroups.js
+++ b/_data/recentGroups.js
@@ -4,11 +4,11 @@ const path = require("path");
 // Recently added groups — update this list when new groups are merged.
 // The build enriches each entry with description and category title from the markdown.
 const recent = [
-  { name: "Vision Zero Vancouver", categorySlug: "volunteer" },
-  { name: "Shoreline Rescue Club", categorySlug: "volunteer" },
+  { name: "Infer Vancouver", categorySlug: "tech-startup" },
+  { name: "Bad Climbers Club", categorySlug: "climbing" },
+  { name: "Kamino Run Club", categorySlug: "run-clubs" },
+  { name: "BlueHour Health", categorySlug: "tech-startup" },
   { name: "Vancouver Gaymers", categorySlug: "board-games" },
-  { name: "Pitch n Putt Player's Club", categorySlug: "hiking-outdoors" },
-  { name: "New West Improv", categorySlug: "improv-comedy" },
   { name: "Vancouver Pen Club", categorySlug: "writing" },
 ];
 

--- a/_includes/partials/sidebar.njk
+++ b/_includes/partials/sidebar.njk
@@ -1,6 +1,6 @@
 <nav class="sidebar" id="sidebar">
   <ul>
-    <li class="sidebar-logo-item"><a href="/" class="sidebar-logo"><span class="logo-city">Vancouver<span class="logo-accent">.</span></span><span class="logo-type">Community Directory</span></a></li>
+    <li class="sidebar-logo-item"><a href="/" class="sidebar-logo"><span class="logo-line">Vancouver</span><span class="logo-line logo-italic">Community</span></a></li>
     {%- for group in groups %}
     <li class="sidebar-group-label">{{ group.label | ampEscape | safe }}</li>
     {%- for cat in collections.categories %}

--- a/src/style.css
+++ b/src/style.css
@@ -135,34 +135,22 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   display: flex;
   flex-direction: column;
   padding: 28px 22px 22px;
-  color: #fff;
   text-decoration: none;
-  margin-bottom: 2px;
 }
 .sidebar-logo:hover { text-decoration: none; opacity: 0.9; }
 .sidebar-logo:visited { color: #fff; }
-
-.logo-city {
+.logo-line {
+  display: block;
   font-family: var(--font-display);
-  font-size: 1.6em;
+  font-size: 1.65em;
   font-weight: 400;
   letter-spacing: -0.02em;
-  line-height: 1.1;
+  line-height: 1.05;
   color: #fff;
 }
-.logo-accent {
+.logo-italic {
+  font-style: italic;
   color: var(--accent);
-}
-.logo-type {
-  font-family: var(--font-body);
-  font-size: 0.62em;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: rgba(255,255,255,0.4);
-  margin-top: 6px;
-  padding-top: 6px;
-  border-top: 1px solid rgba(255,255,255,0.1);
 }
 
 /* Nav list */


### PR DESCRIPTION
## Summary
- Replace corporate "Vancouver." + faint uppercase "COMMUNITY DIRECTORY" with stacked "Vancouver / Community" in Fraunces serif
- Second word in italic accent color for bulletin-board warmth
- Cleaner CSS, fewer classes

## Test plan
- [ ] Verify logo renders correctly on desktop sidebar
- [ ] Verify mobile header still shows "Vancouver Community"
- [ ] Check category pages and homepage both look right