### PR TITLE
Monetization + SEO growth: sponsor system, /advertise page, two flagship guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,12 @@ Apply this test: *"If I'm interested in X, can I go here and find my people?"*
 - PR descriptions should be 1-3 sentences explaining what and why
 - Link to the triggering issue in the PR body when applicable: `Resolves #123`
 
+## Monetization
+
+- **Category sponsors** live in `_data/sponsors.json` (`listings` array; see `_docs`/`_example` in the file). A listing renders a labeled "Community sponsor" card at the top of that category page; categories without a sponsor show a one-line note linking to `/advertise/`. One sponsor per category, `rel="sponsored"` on links, always labeled. Sponsorship never buys, changes, or removes a regular listing.
+- **Pricing** is on `/advertise/` (`content/advertise.njk`): $39/mo or $350/yr per category, $25/issue newsletter classified. Sold by email (vancouver@bolle.co).
+- Community groups are never charged — sponsorships are for businesses (studios, gyms, shops, venues) only, and must pass the same "can I find my people here?" test.
+
 ## Deployment
 
 Cloudflare Pages builds the site on push (`npm run build`) and deploys from `site/`. The `site/` directory is gitignored — never commit built output. The GitHub Action in `.github/workflows/build.yml` runs the build as a CI check only.

--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -1,0 +1,12 @@
+{
+  "_docs": "Category sponsors. Each listing renders a labeled 'Community sponsor' card at the top of its category page. Fields: category (file slug, e.g. 'pottery-ceramics'), name, description (1-2 sentences, written in the site's voice), url, where (optional neighbourhood), cta (optional link text, defaults to 'Visit'). Sold via /advertise/. Keep it to one sponsor per category.",
+  "_example": {
+    "category": "pottery-ceramics",
+    "name": "Example Clay Studio",
+    "description": "Drop-in wheel nights and 6-week intro courses in Mount Pleasant. Beginners welcome.",
+    "url": "https://example.com",
+    "where": "Mount Pleasant",
+    "cta": "See class times"
+  },
+  "listings": []
+}

--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -137,9 +137,51 @@
     </div>
   </div>
 
+  {%- set sponsor = null %}
+  {%- for s in sponsors.listings %}
+    {%- if s.category == page.fileSlug %}{% set sponsor = s %}{% endif %}
+  {%- endfor %}
+
   <div class="category-entries">
+    {%- if sponsor %}
+    <div class="sponsor-card">
+      <span class="sponsor-card-label">Community sponsor</span>
+      <div class="group-card-header">
+        <h2>{{ sponsor.name }}</h2>
+      </div>
+      <p class="group-card-desc">{{ sponsor.description }}</p>
+      {%- if sponsor.where %}
+      <div class="group-card-meta"><span class="group-card-where">&#128205; {{ sponsor.where }}</span></div>
+      {%- endif %}
+      <a href="{{ sponsor.url }}" class="group-card-link" target="_blank" rel="sponsored noopener noreferrer" data-umami-event="sponsor-click" data-umami-event-category="{{ page.fileSlug }}">{{ sponsor.cta or "Visit" }} &rarr;</a>
+    </div>
+    {%- endif %}
     {{ content | stripH1 | cardify | safe }}
+    {%- if not sponsor %}
+    <p class="sponsor-slot-note">Run a studio, shop, or business this crowd would love? <a href="/advertise/" data-umami-event="click-advertise" data-umami-event-source="{{ page.fileSlug }}">Feature it here</a> — it helps keep the directory free.</p>
+    {%- endif %}
   </div>
+
+  {%- set relatedCats = [] %}
+  {%- for cat in collections.categories %}
+    {%- if cat.data.group == groupKey and cat.fileSlug != page.fileSlug and relatedCats.length < 4 %}
+      {%- set relatedCats = relatedCats.concat([cat]) %}
+    {%- endif %}
+  {%- endfor %}
+  {%- if relatedCats.length %}
+  <section class="related-cats">
+    <p class="hp-section-title">More ways to meet people</p>
+    <div class="start-groups">
+      {%- for cat in relatedCats %}
+      <a href="/{{ cat.fileSlug }}/" class="start-group-card" data-umami-event="click-related-category" data-umami-event-category="{{ cat.fileSlug }}">
+        <span class="start-group-name">{{ cat.data.emoji }} {{ cat.data.title }}</span>
+        <span class="start-group-desc">{{ cat.data.description | truncate(100) }}</span>
+      </a>
+      {%- endfor %}
+    </div>
+    <p class="related-cats-more">New in town? <a href="/start-here/">Start here</a> &middot; Feeling stuck? Read <a href="/blog/how-to-make-friends-in-vancouver/">how to make friends in Vancouver</a>.</p>
+  </section>
+  {%- endif %}
 
   {% include "partials/footer.njk" %}
 </main>

--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -21,6 +21,8 @@
         <a href="/submit/">Submit a group</a>
         <a href="/blog/start-a-group/">Start a group</a>
         <a href="/start-here/">New to Vancouver</a>
+        <a href="/blog/how-to-make-friends-in-vancouver/">Make friends here</a>
+        <a href="/advertise/">Sponsor the directory</a>
       </div>
       <div class="site-footer-nav">
         <p class="site-footer-nav-label">Site</p>

--- a/_includes/post.njk
+++ b/_includes/post.njk
@@ -9,7 +9,53 @@
   <meta property="og:type" content="article">
   <meta property="og:url" content="{{ site.url }}/blog/{{ page.fileSlug }}/">
   <meta property="og:image" content="{{ site.url }}/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description or title }}">
+  <meta name="twitter:image" content="{{ site.url }}/og-image.png">
   <link rel="canonical" href="{{ site.url }}/blog/{{ page.fileSlug }}/">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "{{ title | replace('"', '\\"') }}",
+    "description": "{{ description | replace('"', '\\"') }}",
+    "datePublished": "{{ page.date.toISOString() }}",
+    "dateModified": "{{ page.date.toISOString() }}",
+    "mainEntityOfPage": "{{ site.url }}/blog/{{ page.fileSlug }}/",
+    "image": "{{ site.url }}/og-image.png",
+    "author": {
+      "@type": "Person",
+      "name": "Patrick Bollenbach",
+      "url": "https://bollenbach.ca"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Patrick Bollenbach",
+      "url": "https://bollenbach.ca"
+    }
+  }
+  </script>
+  {%- if faq %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {%- for item in faq %}
+      {
+        "@type": "Question",
+        "name": "{{ item.q | replace('"', '\\"') }}",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "{{ item.a | replace('"', '\\"') }}"
+        }
+      }{% if not loop.last %},{% endif %}
+      {%- endfor %}
+    ]
+  }
+  </script>
+  {%- endif %}
 </head>
 <body class="category-page">
 <a href="#main-content" class="skip-link">Skip to content</a>

--- a/content/advertise.njk
+++ b/content/advertise.njk
@@ -1,0 +1,84 @@
+---
+layout: false
+permalink: /advertise/
+eleventyExcludeFromCollections: true
+---
+{%- set totalGroups = 0 %}
+{%- for cat in collections.categories %}
+  {%- set totalGroups = totalGroups + cat.data.groupCount %}
+{%- endfor %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include "partials/head.njk" %}
+  <title>Sponsor the Directory | {{ site.title }}</title>
+  <meta name="description" content="Put your studio, shop, or business in front of people actively looking for community in Vancouver. Simple, honest sponsorships that keep the directory free.">
+  <meta property="og:title" content="Sponsor the Vancouver Community Directory">
+  <meta property="og:description" content="Reach people actively looking for community in Vancouver. Simple, honest sponsorships that keep the directory free.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ site.url }}/advertise/">
+  <meta property="og:image" content="{{ site.url }}/og-image.png">
+  <link rel="canonical" href="{{ site.url }}/advertise/">
+</head>
+<body class="category-page">
+<a href="#main-content" class="skip-link">Skip to content</a>
+{% include "partials/topbar.njk" %}
+<main id="main-content">
+  <div class="cat-hero">
+    <div class="start-hero-wrap">
+      <h1 class="cat-title">Put your business in front of people looking for community.</h1>
+      <p class="cat-desc">This directory helps people in Vancouver find their people — {{ totalGroups }}+ groups across {{ collections.categories.length }} categories. If you run a studio, gym, shop, or venue that belongs in that world, a sponsorship puts you exactly where they're already looking.</p>
+    </div>
+  </div>
+
+  <div class="page-content prose-content">
+
+    <h2>Who visits</h2>
+    <p>Around 2,500 people a month, almost entirely from Google searches like <em>"pottery classes vancouver"</em>, <em>"run clubs vancouver"</em>, or <em>"how to make friends in vancouver"</em>. Nobody lands here by accident — they searched for the exact thing your business offers, in this city, this week. There's also <a href="/#categories">a weekly newsletter</a> that goes out with the newest groups added to the directory.</p>
+    <p>Community groups are always listed free. That never changes. Sponsorships are how businesses — the studios, gyms, and shops that host this city's communities — support the directory and get seen doing it.</p>
+
+    <h2>What you can sponsor</h2>
+
+    <div class="advertise-tiers">
+      <div class="advertise-tier">
+        <h3>Category sponsor</h3>
+        <p class="advertise-tier-price">$39/month <span>or $350/year</span></p>
+        <ul>
+          <li>A featured card at the top of one category page (e.g. Pottery &amp; Ceramics, Climbing, Coworking)</li>
+          <li>Clearly labeled "Community sponsor" — honest, not sneaky</li>
+          <li>Your name, a short description in the site's voice, and a link</li>
+          <li>One sponsor per category, ever. No bidding wars</li>
+          <li>A welcome mention in the newsletter when you start</li>
+        </ul>
+      </div>
+      <div class="advertise-tier">
+        <h3>Newsletter feature</h3>
+        <p class="advertise-tier-price">$25/issue</p>
+        <ul>
+          <li>A short, clearly-marked classified in the weekly Vancouver roundup</li>
+          <li>Written like the rest of the email — a neighbourly recommendation, not ad copy</li>
+          <li>One per issue, first come first served</li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>House rules</h2>
+    <p>This site works because people trust it, so sponsorships are picky on purpose:</p>
+    <ul>
+      <li><strong>Relevant only.</strong> Your business should be somewhere a person could actually meet people — classes, drop-ins, leagues, events, spaces. If it doesn't pass the "can I find my people here?" test, it's not a fit.</li>
+      <li><strong>Always labeled.</strong> Sponsored placements say so, plainly.</li>
+      <li><strong>Editorial stays editorial.</strong> Sponsoring never buys a regular listing, changes one, or removes a competitor. The directory stays honest.</li>
+      <li><strong>I can say no</strong> (and refund you) if it's not working for readers.</li>
+    </ul>
+
+    <h2>Interested?</h2>
+    <p>Email me at <a href="mailto:vancouver@bolle.co?subject=Sponsoring%20the%20directory" data-umami-event="click-advertise-email">vancouver@bolle.co</a> with what you run and which category fits. I'll reply within a couple of days with current traffic numbers for that page and next steps. Payment is a simple monthly invoice — cancel anytime.</p>
+    <p>Not a business, just a group? <a href="/submit/">Submit it here</a> — free, always.</p>
+
+  </div>
+
+  {% include "partials/footer.njk" %}
+</main>
+{% include "partials/scripts.njk" %}
+</body>
+</html>

--- a/content/blog/how-to-make-friends-in-vancouver.md
+++ b/content/blog/how-to-make-friends-in-vancouver.md
@@ -1,0 +1,100 @@
+---
+layout: post
+tags: post
+title: "How to make friends in Vancouver (a practical guide)"
+description: "Why Vancouver feels hard to crack, what actually works, and 40+ categories of groups where you can find your people — most of them free."
+date: 2026-07-05
+faq:
+  - q: "Why is it so hard to make friends in Vancouver?"
+    a: "People here are friendly but busy, social circles formed years ago, and the city's default plan is 'let's grab coffee sometime' — which never happens. The fix is recurring groups: seeing the same faces every week does the work that one-off plans can't."
+  - q: "How do I make friends in Vancouver as an adult in my 30s or 40s?"
+    a: "Join something that meets on a schedule — a run club, book club, supper club, or class — and go three times before deciding if it's for you. Friendship at this age comes from repetition, not chemistry on the first meeting."
+  - q: "Where can I meet people in Vancouver without drinking?"
+    a: "Run clubs, hiking groups, silent book clubs, drawing circles, climbing gyms, language exchanges, volunteer shifts, and morning sauna and cold plunge communities are all built around an activity rather than a bar."
+  - q: "How can I meet people in Vancouver for free?"
+    a: "Most groups in this directory are free: community run clubs, beach salsa with a free beginner lesson, silent book clubs at the library, philosophy discussion groups, hiking clubs, and free drop-in meditation, among many others."
+---
+
+Vancouver has a reputation: beautiful city, hard to crack. People move here for the mountains and then quietly wonder why, two years in, their phone is full of acquaintances and empty of plans. Locals have a name for it — the "Vancouver freeze" — and every few weeks someone posts the same question online: *how does anyone actually make friends here?*
+
+I built this directory because I think the freeze is real but misdiagnosed. Vancouver doesn't lack friendly people. It lacks *default places to keep seeing the same people* — and that, fortunately, is fixable. This guide is everything I'd tell a friend who just moved here.
+
+## The one rule that actually works
+
+Friendship isn't made at events. It's made by **repetition** — seeing the same faces often enough that saying hi becomes automatic, then easy, then something you look forward to. Sociologists call it proximity and repeated, unplanned interaction. You can just call it "joining something that meets every week."
+
+So the rule: **pick something recurring, and go three times before you judge it.**
+
+The first visit you'll feel like an outsider, because you are. The second visit someone will recognize you. The third visit you're a regular. Almost everyone quits after the first visit, which is why almost everyone stays lonely. One-off events — festivals, concerts, big mixers — are fun, but they shuffle the deck every time. Recurring groups stack the deck in your favour.
+
+Everything below is organized around that rule. These are real Vancouver groups that meet on a schedule, most of them free, all of them from [the directory](/).
+
+## If you want the easiest possible start
+
+Some groups exist specifically so that strangers can become friends. You don't need a skill, gear, or a reason:
+
+- **[Social & friend clubs](/social-friend-clubs/)** — groups like We Should Be Friends run park hangs, pottery nights, and neighbourhood book clubs explicitly aimed at building lasting friendships.
+- **[Dinner & supper clubs](/dinner-supper-clubs/)** — DayOfUs pairs you with five strangers at a surprise restaurant every week. Dinner with strangers sounds terrifying and reliably isn't.
+- **[Board games](/board-games/)** — a table, a game, and built-in conversation. The lowest-stakes social format ever invented.
+- **[Pub trivia](/pub-trivia/)** — teams need a fourth. Be the fourth.
+
+If you're brand new to the city, I keep a shorter, hand-picked version of this list at [Start Here](/start-here/).
+
+## If you'd rather sweat than small-talk
+
+Movement is the great Vancouver icebreaker. Talking is easier when you're doing something, and this city's default social currency is being outside:
+
+- **[Run clubs](/run-clubs/)** — the single fastest way to meet people in Vancouver right now. Social Run Club and Striderz are beginner-friendly and free; Vancouver Frontrunners has a no-drop policy and is LGBTQ+ friendly. Nobody cares about your pace.
+- **[Hiking & outdoors](/hiking-outdoors/)** — Y Adventure Kommunity (YAK) exists precisely to make friends through adventures; Wanderung is a 3,600-person mailing list of people posting "who's in this Saturday?"
+- **[Climbing](/climbing/)** — bouldering gyms are the unofficial social clubs of this city. You'll talk to strangers within ten minutes, guaranteed.
+- **[Cycling](/cycling/)**, **[pickleball](/pickleball/)**, and [everything else](/more-sports/) — drop-in sports are repetition machines: same court, same time, same people.
+- **[Dance](/dance/)** — Rueda de la Vida runs free outdoor salsa every Friday with a beginner lesson. No partner needed.
+- **[Sauna & cold plunge](/sauna-cold-plunge/)** — the polar bear crowd is weirdly, wonderfully tight-knit. Shared mild suffering bonds fast.
+
+## If you're more of an indoor person
+
+- **[Book clubs](/book-clubs/)** — Silent Book Club deserves its cult status: you read quietly together, then chat if you feel like it. Introvert heaven.
+- **[Writing](/writing/)** — Shut Up & Write! meets at the library for quiet writing followed by conversation. Supportive and judgment-free.
+- **[Philosophy & discussion](/philosophy-intellectual/)** — the Vancouver Philosophy Salon argues about Plato and Buddha in a friendly way. Great for people who miss real conversation.
+- **[Chess](/chess/)** — Beer & Chess describes itself as "we play chess and get to know people who like chess." That's the whole pitch and it works.
+- **[Creative & art](/creative-art/)** — Draw Around Vancouver runs slow, alcohol-free, beginner-friendly drawing circles.
+- **[Pottery](/pottery-ceramics/)**, **[maker spaces](/maker-spaces/)**, **[photography](/photography/)**, **[film](/film-cinema/)**, **[music & open mics](/music-open-mic/)** — classes and studios are sneaky-good for friendship because they run in multi-week cohorts. Same dozen people, every week, with clay on their hands.
+
+## If you want your specific people
+
+The niches are where the freeze thaws fastest, because showing up already says "we have something in common":
+
+- **[Language exchange](/language-exchange/)** — half of Vancouver speaks a second language; these nights are famously welcoming to newcomers.
+- **[Men's groups](/mens-groups/)** — talking circles like the DUDES Club, because men's loneliness is its own epidemic.
+- **[Volunteering](/volunteer/)** — shared shifts build friendships faster than shared drinks, and Vancouver's community organizations always need hands.
+- **[Tech & startup](/tech-startup/)**, **[astronomy](/astronomy-stargazing/)**, **[birdwatching](/birdwatching/)**, **[foraging](/foraging-nature/)**, **[zines](/zine-risograph/)**, **[tarot](/tarot-astrology/)**, **[karaoke](/karaoke/)**, **[vinyl bars](/vinyl-listening-bars/)** — whatever your thing is, there's a Vancouver group for it. That's the entire point of [the directory](/).
+
+## A few honest tips from watching hundreds of these groups
+
+**Go alone.** It feels harder and works better. Groups absorb solo newcomers instantly; pairs talk to each other.
+
+**Say yes to the after-thing.** The run isn't where friendships form — the coffee after the run is. When someone says "a few of us are grabbing food," that's the actual invitation. Take it.
+
+**Be the one who remembers names.** It's a superpower and it's free.
+
+**Trade one app hour for one group hour.** Apps optimize for browsing people; groups optimize for knowing them.
+
+**And if nothing on this site fits you — start the thing.** Vancouver rewards initiators, and it's far easier than it sounds. I wrote a full guide: [how to start a community group in Vancouver](/blog/start-a-group/), including free meeting rooms at 15 library branches.
+
+## Frequently asked questions
+
+**Why is it so hard to make friends in Vancouver?**
+Not because people are cold — because the city runs on "we should hang out sometime," which is a plan with no date. Recurring groups replace *sometime* with *every Wednesday*, and that's the whole trick.
+
+**I'm in my 30s/40s. Is it too late?**
+No, but the method changes. School handed you repetition for free; now you have to schedule it. Join something weekly and give it a month. Adults make friends the same way kids do — they just have to do it on purpose.
+
+**I don't drink. Where do I meet people?**
+Most of this list, honestly: [run clubs](/run-clubs/), [hiking](/hiking-outdoors/), [silent book club](/book-clubs/), [drawing circles](/creative-art/), [climbing](/climbing/), [meditation](/mindfulness-meditation/), [sauna crews](/sauna-cold-plunge/). Vancouver might be the best sober-social city in Canada.
+
+**What's actually free?**
+More than you'd think. Community run clubs, Friday beach salsa, library book clubs, philosophy meetups, hiking groups, drop-in meditation — the directory marks free groups on each category page.
+
+---
+
+*This guide is part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city. Know a group that belongs here? [Add it](/submit/).*

--- a/content/blog/things-to-do-alone-in-vancouver.md
+++ b/content/blog/things-to-do-alone-in-vancouver.md
@@ -1,0 +1,72 @@
+---
+layout: post
+tags: post
+title: "Things to do alone in Vancouver (that put you around people)"
+description: "Solo-friendly things to do in Vancouver where showing up by yourself is completely normal — and where regulars quietly become friends."
+date: 2026-07-05
+faq:
+  - q: "What can I do alone in Vancouver?"
+    a: "Silent book clubs, run clubs, drop-in climbing, drawing circles, open mics, language exchanges, sauna and cold plunge sessions, volunteer shifts, and pub trivia all welcome solo drop-ins — most people arrive alone."
+  - q: "Is it weird to go to things alone in Vancouver?"
+    a: "No — at most recurring community groups, arriving solo is the norm. Groups absorb solo newcomers much faster than pairs, because regulars naturally talk to someone standing alone."
+  - q: "What are free things to do alone in Vancouver?"
+    a: "Free options include community run clubs, silent book clubs at the library, free Friday outdoor salsa with a beginner lesson, hiking groups, philosophy discussion nights, and drop-in meditation sessions."
+---
+
+Doing things alone in Vancouver is easy — this city was practically designed for solo hikes and solo coffee. The harder question, and the one people are usually really asking, is: *what can I do alone that doesn't keep me alone?*
+
+Here's the secret about the activities below: **almost everyone else showed up alone too.** These are the places where being solo isn't just acceptable — it's the default entry ticket, and where going twice makes you a regular. Every link goes to the [directory](/), where you'll find the actual groups, times, and websites.
+
+## Quietly social (no talking required)
+
+Perfect if you want company without conversation — or want the conversation to be optional.
+
+- **Silent Book Club** — the ideal solo activity: strangers reading together at a pub or library, chatting only if they feel like it. Find it under [book clubs](/book-clubs/).
+- **Shut Up & Write!** — same formula for writers: quiet writing time, then optional conversation. Under [writing](/writing/).
+- **Drawing circles** — Draw Around Vancouver runs slow, alcohol-free sessions where everyone's focused on their sketchbook. Under [creative & art](/creative-art/).
+- **[Mindfulness & meditation](/mindfulness-meditation/)** — drop-in sits are inherently solo, together.
+- **[Vinyl & listening bars](/vinyl-listening-bars/)** — going alone to listen to records is not just normal, it's kind of the point.
+
+## Solo by design, social by accident
+
+Activities where you participate as an individual — but the same faces show up every week, and that's how it starts.
+
+- **[Run clubs](/run-clubs/)** — nobody brings a friend to a run club; the run club *is* the friends. Free, beginner-friendly, and everywhere right now.
+- **[Climbing](/climbing/)** — bouldering is the best solo-social sport ever invented. You need no partner, and strangers spontaneously coach each other between attempts.
+- **[Sauna & cold plunge](/sauna-cold-plunge/)** — show up alone, freeze with strangers, leave with people who cheer when you get in the ocean in January.
+- **[Hiking & outdoors](/hiking-outdoors/)** — group hikes are the safe way to do the mountains solo. Wanderung's mailing list is basically "solo hikers seeking same."
+- **[Pickleball](/pickleball/)** and [drop-in sports](/more-sports/) — drop-in formats rotate you through partners automatically. Arriving alone is the standard.
+- **[Cycling](/cycling/)** — group rides run on the same logic as run clubs, with better views.
+
+## Solo with a built-in reason to talk
+
+Formats that hand you conversation, so you don't have to manufacture it.
+
+- **[Language exchange](/language-exchange/)** — the entire format is "talk to strangers, kindly." The most newcomer-friendly rooms in the city.
+- **[Board games](/board-games/)** — game nights are engineered for odd numbers; tables always need one more.
+- **[Pub trivia](/pub-trivia/)** — tell the host you're solo and you'll be adopted by a team before round one.
+- **[Chess](/chess/)** — Beer & Chess and park boards: sit down, play, talk. Centuries of proof it works.
+- **[Philosophy & discussion](/philosophy-intellectual/)** — discussion nights where showing up alone with opinions is the whole format.
+- **[Dance](/dance/)** — social dance rotates partners, so coming alone is actually the correct way. Free Friday beach salsa includes a beginner lesson.
+
+## Solo with your hands busy
+
+- **[Pottery & ceramics](/pottery-ceramics/)** — drop-in wheel nights and multi-week courses. Clay is a great social lubricant.
+- **[Maker spaces](/maker-spaces/)** — work on your own project surrounded by people doing the same.
+- **[Photography](/photography/)** — photo walks are the introvert's group activity: together, but behind a lens.
+- **[Music & open mics](/music-open-mic/)** — go alone to perform or just to watch; open mic rooms are warm to solo newcomers.
+- **[Volunteering](/volunteer/)** — the most reliable of all: a shift gives you a role, a task, and teammates. No small talk required to start.
+
+## A few notes on going solo
+
+**Solo beats duo for meeting people.** A pair reads as "closed"; a person alone reads as "open." Regulars will talk to you *because* you're alone.
+
+**Pick recurring over one-off.** A festival alone is still a festival alone. A weekly thing alone becomes, by week three, a weekly thing with people who know your name. (More on that in [how to make friends in Vancouver](/blog/how-to-make-friends-in-vancouver/).)
+
+**The after-thing is the real thing.** When the run or the sit or the game ends and someone says "we usually grab food" — go. That's where regulars become friends.
+
+**New to the city?** The [Start Here](/start-here/) page is a hand-picked shortlist of the most welcoming, just-show-up groups.
+
+---
+
+*This guide is part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city. Know a group that belongs here? [Add it](/submit/).*

--- a/content/sitemap.njk
+++ b/content/sitemap.njk
@@ -17,9 +17,36 @@ eleventyExcludeFromCollections: true
     <priority>0.8</priority>
   </url>
   {%- endfor %}
+  {%- for post in collections.posts %}
+  <url>
+    <loc>{{ site.url }}/blog/{{ post.fileSlug }}/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  {%- endfor %}
+  <url>
+    <loc>{{ site.url }}/start-here/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/blog/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/about/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
   <url>
     <loc>{{ site.url }}/submit/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/advertise/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
   </url>
 </urlset>

--- a/src/style.css
+++ b/src/style.css
@@ -2300,3 +2300,112 @@ textarea.form-input { resize: vertical; }
   /* Footer links stack */
   .hp-footer-links { flex-wrap: wrap; gap: 10px; }
 }
+
+/* ========================================
+   SPONSORSHIP — featured card, unsold slot, advertise page
+   ======================================== */
+.sponsor-card {
+  grid-column: 1 / -1;
+  position: relative;
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 20px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 580px;
+}
+.sponsor-card-label {
+  font-size: 0.68em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--accent);
+}
+.sponsor-card .group-card-header h2 {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+.sponsor-slot-note {
+  grid-column: 1 / -1;
+  margin-top: 8px;
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+.sponsor-slot-note a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.advertise-tiers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 20px 0 28px;
+  max-width: 720px;
+}
+.advertise-tier {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px 22px;
+}
+.advertise-tier h3 {
+  font-family: var(--font-display);
+  font-size: 1.15em;
+  margin: 0 0 4px;
+}
+.advertise-tier-price {
+  color: var(--accent);
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+.advertise-tier-price span {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 0.85em;
+}
+.advertise-tier ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.advertise-tier li {
+  font-size: 0.92em;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  padding-left: 18px;
+  position: relative;
+  margin: 6px 0;
+}
+.advertise-tier li::before {
+  content: "·";
+  position: absolute;
+  left: 4px;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* ========================================
+   RELATED CATEGORIES — internal links at category page bottom
+   ======================================== */
+.related-cats {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 8px 32px 48px;
+}
+.related-cats .start-groups {
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+.related-cats-more {
+  margin-top: 16px;
+  font-size: 0.9em;
+  color: var(--text-muted);
+}
+@media (max-width: 640px) {
+  .related-cats { padding: 4px 16px 40px; }
+}


### PR DESCRIPTION
Turns the site's ~80/day organic traffic into a revenue path and compounds the SEO that's driving it.

## Monetization (primary revenue: featured listings — the proven model for niche directories)
- **Category sponsor system**: `_data/sponsors.json` drives a clearly-labeled "Community sponsor" card at the top of a category page (`rel="sponsored"`, Umami click tracking). Unsold categories show a subtle one-line "Feature it here" note linking to `/advertise/` — the slot sells itself. Ships empty; adding a sponsor is a one-line JSON edit.
- **`/advertise/` page**: pricing ($39/mo or $350/yr per category, $25/issue newsletter classified), honest audience numbers, and house rules (always labeled, editorial stays editorial, groups never pay). CTA is a prefilled mailto — no payment infra needed to start selling.

## SEO growth
- **Two long-form guides** targeting the site's biggest untapped queries: *How to make friends in Vancouver* (the "Vancouver freeze" query the site is uniquely positioned to own) and *Things to do alone in Vancouver*. Both carry Article + FAQPage structured data and ~40 internal links each into category pages.
- **Sitemap fix**: blog posts, `/start-here/`, `/blog/`, `/about/` were missing from `sitemap.xml` entirely — now included, plus `/advertise/`.
- **Related-categories block** on every category page ("More ways to meet people") — internal linking + pages/session.
- **Blog layout upgrades**: Article JSON-LD, optional `faq` frontmatter → FAQPage schema, Twitter card tags.

Verified: clean 11ty build (54 files), all JSON-LD blocks parse, zero broken internal links in the new guides, sponsor card render tested with a temp listing and reverted. Monetization model documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_