### PR TITLE
Automate newsletter classifieds + run build CI on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,15 @@ on:
       - 'static/**'
       - 'eleventy.config.js'
       - 'package.json'
+  pull_request:
+    paths:
+      - 'content/**'
+      - '_includes/**'
+      - '_data/**'
+      - 'src/**'
+      - 'static/**'
+      - 'eleventy.config.js'
+      - 'package.json'
 
 jobs:
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ Apply this test: *"If I'm interested in X, can I go here and find my people?"*
 
 - **Category sponsors** live in `_data/sponsors.json` (`listings` array; see `_docs`/`_example` in the file). A listing renders a labeled "Community sponsor" card at the top of that category page; categories without a sponsor show a one-line note linking to `/advertise/`. One sponsor per category, `rel="sponsored"` on links, always labeled. Sponsorship never buys, changes, or removes a regular listing.
 - **Pricing** is on `/advertise/` (`content/advertise.njk`): $39/mo or $350/yr per category, $25/issue newsletter classified. Sold by email (vancouver@bolle.co).
+- **Newsletter classifieds** live in `_data/classifieds.json` (see `_docs` in the file). The weekly newsletter script (`scripts/newsletter.mjs`) includes the first active listing per issue, clearly labeled as paid; entries expire via their `until` date. Preview with `node scripts/newsletter.mjs --dry-run`.
 - Community groups are never charged — sponsorships are for businesses (studios, gyms, shops, venues) only, and must pass the same "can I find my people here?" test.
 
 ## Deployment

--- a/_data/classifieds.json
+++ b/_data/classifieds.json
@@ -1,0 +1,8 @@
+{
+  "_docs": "Newsletter classifieds ($25/issue, sold via /advertise/). The newsletter script includes the first active listing per issue, clearly labeled. Fields: text (1-2 neighborly sentences, markdown links allowed), until (optional YYYY-MM-DD last-run date — omit for run-until-removed). Entries past their 'until' date are skipped automatically.",
+  "_example": {
+    "text": "Example Clay Studio in Mount Pleasant has two spots left in its 6-week beginner wheel course starting August. [See class times](https://example.com).",
+    "until": "2026-08-01"
+  },
+  "listings": []
+}

--- a/scripts/newsletter.mjs
+++ b/scripts/newsletter.mjs
@@ -9,9 +9,10 @@ const BUTTONDOWN_API = "https://api.buttondown.com/v1";
 const API_KEY = process.env.BUTTONDOWN_API_KEY;
 const SITE_URL = "https://vancouvercommunity.org";
 const CONTENT_DIR = join(process.cwd(), "content");
+const DRY_RUN = process.argv.includes("--dry-run");
 
-if (!API_KEY) {
-  console.error("BUTTONDOWN_API_KEY is required");
+if (!API_KEY && !DRY_RUN) {
+  console.error("BUTTONDOWN_API_KEY is required (or pass --dry-run to preview)");
   process.exit(1);
 }
 
@@ -82,6 +83,20 @@ function getSpotlightCategory() {
   return { title, emoji, slug, groups };
 }
 
+// ── Classified (one per issue, sold via /advertise/) ───────────
+
+function getClassified() {
+  try {
+    const data = JSON.parse(
+      readFileSync(join(process.cwd(), "_data", "classifieds.json"), "utf-8")
+    );
+    const today = new Date().toISOString().slice(0, 10);
+    return (data.listings || []).find((c) => c.text && (!c.until || c.until >= today)) || null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Pretty category name from slug ─────────────────────────────
 
 function prettyCategory(slug) {
@@ -133,7 +148,7 @@ async function getOpener() {
 
 // ── Email HTML template ────────────────────────────────────────
 
-async function buildEmail(adds, spotlight) {
+async function buildEmail(adds, spotlight, classified) {
   let sections = "";
 
   // New additions
@@ -158,6 +173,13 @@ async function buildEmail(adds, spotlight) {
     sections += `[All ${spotlight.title} →](${SITE_URL}/${spotlight.slug})\n\n`;
   }
 
+  // Classified (clearly labeled, one per issue)
+  if (classified) {
+    sections += `## Classified\n\n`;
+    sections += `${classified.text}\n\n`;
+    sections += `*Classifieds are paid and keep the directory free — [book one](${SITE_URL}/advertise/).*\n\n`;
+  }
+
   return await buildBody(sections);
 }
 
@@ -169,13 +191,14 @@ ${sections}
 
 ---
 
-[Browse the directory](${SITE_URL})`;
+[Browse the directory](${SITE_URL}) · [Sponsor the directory](${SITE_URL}/advertise/)`;
 }
 
 // ── Main ───────────────────────────────────────────────────────
 
 const changes = getRecentChanges();
 const spotlight = getSpotlightCategory();
+const classified = getClassified();
 
 const datePart = new Date().toLocaleDateString("en-CA", { month: "short", day: "numeric" });
 
@@ -188,7 +211,12 @@ if (changes.adds.length > 0) {
   subject = `${spotlight?.emoji} ${spotlight?.title} — groups you might not know about`;
 }
 
-const html = await buildEmail(changes.adds, spotlight);
+const html = await buildEmail(changes.adds, spotlight, classified);
+
+if (DRY_RUN) {
+  console.log(`\nSubject: ${subject}\n\n${html}`);
+  process.exit(0);
+}
 
 // Create draft in Buttondown
 const res = await fetch(`${BUTTONDOWN_API}/emails`, {


### PR DESCRIPTION
Follow-up to #130 — makes the $25/issue newsletter classified a real, automated product and closes the CI gap.

- **`_data/classifieds.json`**: classified listings for the weekly newsletter. The script includes the first active listing per issue, clearly labeled *"Classifieds are paid and keep the directory free"*, and auto-expires entries past their `until` date. Booking a classified is now a one-line JSON edit.
- **`scripts/newsletter.mjs`**: classified section, a "Sponsor the directory" footer link in every issue (free house ad to ~weekly inboxes), and a `--dry-run` flag to preview the email locally without a Buttondown key.
- **`build.yml`**: now also runs on `pull_request` — previously PRs had no CI at all; the build only ran after merging to main.

Tested via `--dry-run`: no classified → no section; expired + active entries → expired skipped, active rendered with the paid label; data file restored to empty after testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_