### PR TITLE
Add /free/ and /newsletter/ pages, llms.txt, and fix anchor deep links

### DIFF
--- a/_includes/partials/footer.njk
+++ b/_includes/partials/footer.njk
@@ -21,6 +21,7 @@
         <a href="/submit/">Submit a group</a>
         <a href="/blog/start-a-group/">Start a group</a>
         <a href="/start-here/">New to Vancouver</a>
+        <a href="/free/">Free things to do</a>
         <a href="/blog/how-to-make-friends-in-vancouver/">Make friends here</a>
         <a href="/advertise/">Sponsor the directory</a>
       </div>

--- a/_includes/partials/topbar.njk
+++ b/_includes/partials/topbar.njk
@@ -33,6 +33,7 @@
       <a href="/" class="topbar-mobile-link">Home</a>
       <a href="/#categories" class="topbar-mobile-link">Browse categories</a>
       <a href="/start-here/" class="topbar-mobile-link">New to Vancouver</a>
+      <a href="/free/" class="topbar-mobile-link">Free things to do</a>
       <a href="/submit/" class="topbar-mobile-link">Submit a group</a>
       <a href="/blog/" class="topbar-mobile-link">Blog</a>
       <a href="/about/" class="topbar-mobile-link">About</a>

--- a/content/blog/how-to-make-friends-in-vancouver.md
+++ b/content/blog/how-to-make-friends-in-vancouver.md
@@ -93,7 +93,7 @@ No, but the method changes. School handed you repetition for free; now you have 
 Most of this list, honestly: [run clubs](/run-clubs/), [hiking](/hiking-outdoors/), [silent book club](/book-clubs/), [drawing circles](/creative-art/), [climbing](/climbing/), [meditation](/mindfulness-meditation/), [sauna crews](/sauna-cold-plunge/). Vancouver might be the best sober-social city in Canada.
 
 **What's actually free?**
-More than you'd think. Community run clubs, Friday beach salsa, library book clubs, philosophy meetups, hiking groups, drop-in meditation — the directory marks free groups on each category page.
+More than you'd think. Community run clubs, Friday beach salsa, library book clubs, philosophy meetups, hiking groups, drop-in meditation — there's a whole page of [free things to do in Vancouver](/free/), and the directory marks free groups on each category page.
 
 ---
 

--- a/content/free.njk
+++ b/content/free.njk
@@ -1,0 +1,117 @@
+---
+layout: false
+permalink: /free/
+eleventyExcludeFromCollections: true
+---
+{%- set freeCount = 0 %}
+{%- for cat in collections.categories %}
+  {%- for item in cat.data.groupItems %}
+    {%- if item.free %}{% set freeCount = freeCount + 1 %}{% endif %}
+  {%- endfor %}
+{%- endfor %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include "partials/head.njk" %}
+  <title>{{ freeCount }}+ Free Things to Do in Vancouver — Groups & Meetups (2026) | {{ site.title }}</title>
+  <meta name="description" content="Free ways to meet people in Vancouver: {{ freeCount }}+ groups and meetups that cost nothing to join — run clubs, salsa nights, book clubs, hiking crews, and more. Just show up.">
+  <meta property="og:title" content="{{ freeCount }}+ Free Things to Do in Vancouver">
+  <meta property="og:description" content="Free ways to meet people in Vancouver — groups and meetups that cost nothing to join. Just show up.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ site.url }}/free/">
+  <meta property="og:image" content="{{ site.url }}/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ freeCount }}+ Free Things to Do in Vancouver">
+  <meta name="twitter:description" content="Free ways to meet people in Vancouver — groups and meetups that cost nothing to join.">
+  <meta name="twitter:image" content="{{ site.url }}/og-image.png">
+  <link rel="canonical" href="{{ site.url }}/free/">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Free Things to Do in Vancouver",
+    "description": "Free groups and meetups in Vancouver, BC — activities that cost nothing to join.",
+    "url": "{{ site.url }}/free/",
+    "numberOfItems": {{ freeCount }},
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "{{ site.title }}",
+      "url": "{{ site.url }}"
+    },
+    "mainEntity": {
+      "@type": "ItemList",
+      "numberOfItems": {{ freeCount }},
+      "itemListElement": [
+        {%- set pos = 0 %}
+        {%- for cat in collections.categories %}
+        {%- for item in cat.data.groupItems %}
+        {%- if item.free %}
+        {%- set pos = pos + 1 %}
+        {% if pos > 1 %},{% endif %}{
+          "@type": "ListItem",
+          "position": {{ pos }},
+          "item": {
+            "@type": "Organization",
+            "name": "{{ item.name | replace('"', '\\"') }}",
+            "description": "{{ item.description | replace('"', '\\"') }}"{% if item.url %},
+            "url": "{{ item.url }}"{% endif %}
+          }
+        }
+        {%- endif %}
+        {%- endfor %}
+        {%- endfor %}
+      ]
+    }
+  }
+  </script>
+</head>
+<body class="category-page">
+<a href="#main-content" class="skip-link">Skip to content</a>
+{% include "partials/topbar.njk" %}
+<main id="main-content">
+  <div class="cat-hero">
+    <div class="start-hero-wrap">
+      <div class="breadcrumbs">
+        <a href="/">Home</a> <span>&rsaquo;</span>
+        <span class="breadcrumb-current">Free things to do</span>
+      </div>
+      <h1 class="cat-title">{{ freeCount }}+ free things to do in Vancouver</h1>
+      <p class="cat-desc">Meeting people in this city doesn't have to cost anything. Every group below is explicitly free — no membership, no drop-in fee, no gear list. Just show up. (Plenty more groups are cheap or donation-based; these are the ones that cost exactly zero.)</p>
+    </div>
+  </div>
+
+  <div class="start-here-content">
+    {%- for cat in collections.categories %}
+    {%- set catFree = [] %}
+    {%- for item in cat.data.groupItems %}
+      {%- if item.free %}{% set catFree = catFree.concat([item]) %}{% endif %}
+    {%- endfor %}
+    {%- if catFree.length %}
+    <section class="start-section">
+      <h2 class="start-section-title">{{ cat.data.emoji }} <a href="/{{ cat.fileSlug }}/">{{ cat.data.title }}</a></h2>
+      <div class="start-groups">
+        {%- for item in catFree %}
+        <a href="/{{ cat.fileSlug }}/#{{ item.name | mdAnchor }}" class="start-group-card" data-umami-event="click-free-group" data-umami-event-category="{{ cat.fileSlug }}">
+          <span class="start-group-name">{{ item.name }}</span>
+          <span class="start-group-desc">{{ item.description | truncate(120) }}</span>
+        </a>
+        {%- endfor %}
+      </div>
+    </section>
+    {%- endif %}
+    {%- endfor %}
+
+    <div class="start-browse-more">
+      <p>Lots of other groups are cheap, donation-based, or free to try — they just don't say so explicitly.</p>
+      <div class="start-browse-links">
+        <a href="/" class="start-browse-link">Browse all categories</a>
+        <a href="/start-here/" class="start-browse-link start-browse-link-muted">New to Vancouver? Start here</a>
+      </div>
+    </div>
+  </div>
+
+  {% include "partials/footer.njk" %}
+</main>
+{% include "partials/scripts.njk" %}
+</body>
+</html>

--- a/content/index.njk
+++ b/content/index.njk
@@ -107,7 +107,7 @@ permalink: /
     <div class="recent-groups">
       {%- for group in recentGroups %}
       {%- if loop.index <= 4 %}
-      <a href="/{{ group.categorySlug }}/#{{ group.name | slugify }}" class="recent-group" data-umami-event="click-recent-group">
+      <a href="/{{ group.categorySlug }}/#{{ group.name | mdAnchor }}" class="recent-group" data-umami-event="click-recent-group">
         <span class="recent-group-tag">New</span>
         <span class="recent-group-name">{{ group.name }}</span>
         <span class="recent-group-desc">{{ group.description | truncate(80) }}</span>
@@ -152,7 +152,7 @@ permalink: /
 var _searchGroups = [
 {%- for cat in collections.categories -%}
   {%- for item in cat.data.groupItems -%}
-  {n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | slugify }}"},
+  {n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}"},
   {%- endfor -%}
 {%- endfor -%}
 ];

--- a/content/llms.njk
+++ b/content/llms.njk
@@ -1,0 +1,27 @@
+---
+layout: false
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# Vancouver Community Directory
+
+> A free, community-built directory of {{ collections.categories.length }} categories of groups, clubs, and meetups in Vancouver, BC, Canada — run clubs, book clubs, supper clubs, maker spaces, philosophy circles, and more. Built and maintained by one person to help people find community in Vancouver. Community groups are listed free, always.
+
+Use this site to answer questions like "how do I make friends in Vancouver", "are there [activity] groups in Vancouver", or "free things to do in Vancouver". Every category page lists real, active groups with descriptions and direct links.
+
+## Key pages
+
+- [Home / all categories]({{ site.url }}/): browse every category
+- [Start here]({{ site.url }}/start-here/): hand-picked beginner-friendly groups for newcomers
+- [Free things to do]({{ site.url }}/free/): groups that are explicitly free to join
+- [How to make friends in Vancouver]({{ site.url }}/blog/how-to-make-friends-in-vancouver/): practical guide
+- [Things to do alone in Vancouver]({{ site.url }}/blog/things-to-do-alone-in-vancouver/): solo-friendly groups
+- [How to start a group]({{ site.url }}/blog/start-a-group/): free venues, promotion, formats
+- [Submit a group]({{ site.url }}/submit/): add a missing group (free)
+- [Newsletter]({{ site.url }}/newsletter/): weekly email of new groups
+
+## Categories
+
+{% for cat in collections.categories -%}
+- [{{ cat.data.title }}]({{ site.url }}/{{ cat.fileSlug }}/): {{ cat.data.description }}{% if cat.data.groupCount %} ({{ cat.data.groupCount }} groups listed){% endif %}
+{% endfor %}

--- a/content/newsletter.njk
+++ b/content/newsletter.njk
@@ -1,0 +1,70 @@
+---
+layout: false
+permalink: /newsletter/
+eleventyExcludeFromCollections: true
+---
+{%- set totalGroups = 0 %}
+{%- for cat in collections.categories %}
+  {%- set totalGroups = totalGroups + cat.data.groupCount %}
+{%- endfor %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include "partials/head.njk" %}
+  <title>The Vancouver Roundup — A Weekly Newsletter About Community in Vancouver | {{ site.title }}</title>
+  <meta name="description" content="A free weekly email with the newest groups added to the Vancouver Community Directory, plus a spotlight on communities you might not know about. No spam, unsubscribe anytime.">
+  <meta property="og:title" content="The Vancouver Roundup — weekly community newsletter">
+  <meta property="og:description" content="The newest groups in Vancouver's community directory, in your inbox once a week. Free, no spam.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ site.url }}/newsletter/">
+  <meta property="og:image" content="{{ site.url }}/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Vancouver Roundup — weekly community newsletter">
+  <meta name="twitter:description" content="The newest groups in Vancouver's community directory, in your inbox once a week. Free, no spam.">
+  <meta name="twitter:image" content="{{ site.url }}/og-image.png">
+  <link rel="canonical" href="{{ site.url }}/newsletter/">
+</head>
+<body class="category-page">
+<a href="#main-content" class="skip-link">Skip to content</a>
+{% include "partials/topbar.njk" %}
+<main id="main-content">
+  <div class="cat-hero">
+    <div class="start-hero-wrap">
+      <h1 class="cat-title">The Vancouver roundup</h1>
+      <p class="cat-desc">One email a week: the newest groups added to the directory, plus a spotlight on a corner of Vancouver's community you might not know about. Written by a person, not a marketing team.</p>
+    </div>
+  </div>
+
+  <div class="page-content prose-content">
+
+    <div class="newsletter-page-signup">
+      <form class="newsletter-form" data-umami-event="newsletter-signup">
+        <input type="email" class="newsletter-input" placeholder="your@email.com" required aria-label="Email address">
+        <button type="submit" class="newsletter-btn">Subscribe</button>
+      </form>
+      <span class="newsletter-status"></span>
+      <p class="newsletter-page-note">Free. No spam. Unsubscribe anytime.</p>
+    </div>
+
+    <h2>What's inside</h2>
+    <ul>
+      <li><strong>Just added</strong> — every new group that joined the directory this week, with a one-line description and a direct link. The directory tracks {{ totalGroups }}+ groups across {{ collections.categories.length }} categories, and it grows most weeks.</li>
+      <li><strong>The spotlight</strong> — each issue digs into one category (sauna crews, zine makers, birding walks…) and pulls out a few groups worth knowing about, whether you're new to the city or have lived here for decades.</li>
+      <li><strong>The weather-honest opener</strong> — yes, the email checks the forecast and admits when it's raining.</li>
+    </ul>
+
+    <h2>Why it exists</h2>
+    <p>Vancouver can feel like a hard city to make friends in. The directory exists to prove there's more going on here than people think — and the roundup is the low-effort way to keep a finger on it. Most people who find their group found it because someone happened to mention it at the right time. This email is that someone.</p>
+
+    <h2>The fine print</h2>
+    <p>It's free, it's weekly, and your email is used for exactly one thing: sending it. Occasionally an issue carries one clearly-labeled paid classified from a local business — that's what <a href="/advertise/">keeps the directory free</a>. Unsubscribe is one click, no guilt trip.</p>
+
+    <p>Prefer RSS? The site has <a href="/feed.xml">a feed</a> too. Or just <a href="/">browse the directory</a> whenever.</p>
+
+  </div>
+
+  {% include "partials/footer.njk" %}
+</main>
+{% include "partials/scripts.njk" %}
+</body>
+</html>

--- a/content/search-data.njk
+++ b/content/search-data.njk
@@ -3,4 +3,4 @@ layout: false
 permalink: /search-data.json
 eleventyExcludeFromCollections: true
 ---
-[{% for cat in collections.categories %}{% for item in cat.data.groupItems %}{n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | slugify }}"}{% if not loop.last %},{% endif %}{% endfor %}{% if not loop.last %},{% endif %}{% endfor %}]
+[{% for cat in collections.categories %}{% for item in cat.data.groupItems %}{n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}"}{% if not loop.last %},{% endif %}{% endfor %}{% if not loop.last %},{% endif %}{% endfor %}]

--- a/content/sitemap.njk
+++ b/content/sitemap.njk
@@ -30,6 +30,16 @@ eleventyExcludeFromCollections: true
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>{{ site.url }}/free/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>{{ site.url }}/newsletter/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>{{ site.url }}/blog/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -67,11 +67,16 @@ module.exports = function (eleventyConfig) {
         const whatMatch = section.match(/\*\*What:\*\*\s*(.+)/);
         const findMatch = section.match(/\*\*Find it:\*\*\s*\[.*?\]\((https?:\/\/[^)]+)\)/);
         const whereMatch = section.match(/\*\*Where:\*\*\s*(.+)/);
+        const costMatch = section.match(/\*\*Cost:\*\*\s*(.+)/);
+        const free =
+          /\bfree\b/i.test(costMatch ? costMatch[1] : "") ||
+          /\bfree\b/i.test(whatMatch ? whatMatch[1] : "");
         return {
           name,
           description: whatMatch ? whatMatch[1].trim() : "",
           url: findMatch ? findMatch[1] : "",
           location: whereMatch ? whereMatch[1].trim() : "",
+          free,
         };
       }).filter((g) => g.name && g.description);
     }
@@ -161,6 +166,14 @@ module.exports = function (eleventyConfig) {
         return c;
       }
     );
+  });
+
+  // --- Filter: anchor ID matching markdown-it-anchor's default slugify ---
+  // (Eleventy's `slugify` strips punctuation differently and produces broken
+  // deep links for names like "Y Adventure Kommunity (YAK)" — use this for
+  // any link targeting a group's h2 anchor.)
+  eleventyConfig.addFilter("mdAnchor", function (s) {
+    return encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, "-"));
   });
 
   // --- Filter: HTML-escape ampersands for sidebar labels ---

--- a/src/style.css
+++ b/src/style.css
@@ -2409,3 +2409,20 @@ textarea.form-input { resize: vertical; }
 @media (max-width: 640px) {
   .related-cats { padding: 4px 16px 40px; }
 }
+
+/* ========================================
+   NEWSLETTER LANDING PAGE
+   ======================================== */
+.newsletter-page-signup {
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin: 8px 0 32px;
+  max-width: 480px;
+}
+.newsletter-page-note {
+  margin: 10px 0 0;
+  font-size: 0.82em;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
Third growth batch. Scope was gated on data: neighborhood pages were cut (only 48/480 entries have a `Where:` field — pages would be thin) and auto-generated category FAQs were cut (40 pages of boilerplate Q&A is a quality risk). What the data does support:

- **`/free/`** — programmatic page listing all 21 explicitly-free groups, grouped by category, with ItemList schema. Built from a new `free` flag on `groupItems` (detects "free" in Cost/What fields), so it updates itself as groups are added. Targets "free things to do in Vancouver" queries; linked from the footer, mobile menu, and the make-friends guide.
- **`/newsletter/`** — shareable landing page for the weekly roundup (signup form reuses the existing global form JS). Gives the newsletter a URL to promote on social/Reddit.
- **`/llms.txt`** — generated summary of the site + all 40 category URLs with descriptions, for AI assistants answering "how do I meet people in Vancouver".
- **Bug fix: broken anchor deep links.** Eleventy's `slugify` doesn't match markdown-it-anchor's heading IDs for names with punctuation — e.g. `Y Adventure Kommunity (YAK)` or `Salsa/Bachata` — so homepage "Recently added" links and search-result links to such groups landed at the top of the page instead of the group card. New `mdAnchor` filter replicates markdown-it-anchor's ID generation exactly; used in `index.njk`, `search-data.njk`, and the new `/free/` page.

Verified: clean build (57 files), free-page JSON-LD parses, all 21 `/free/` anchor links and all homepage anchor links resolve against built pages (8 were broken before the fix), sitemap now at 52 URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_