### PR TITLE
Design batch: warmer homepage, honest counts, centered prose, resilient animations

### DIFF
--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -124,15 +124,21 @@
           <span id="page-views" class="cat-views"></span>
         </div>
       </div>
-      <div class="hp-hero-newsletter">
-        <p class="hp-hero-nl-heading">The Vancouver roundup</p>
-        <p class="hp-hero-nl-desc">A weekly email with the newest groups added to the directory, plus community picks.</p>
-        <form class="newsletter-form" data-umami-event="newsletter-signup">
-          <input type="email" class="newsletter-input" placeholder="your@email.com" required aria-label="Email address">
-          <button type="submit" class="newsletter-btn">Subscribe</button>
-        </form>
-        <span class="newsletter-status"></span>
-        <p class="hp-hero-nl-note">Free. No spam. Unsubscribe anytime.</p>
+      {%- set freeInCat = 0 %}
+      {%- for item in groupItems %}
+        {%- if item.free %}{% set freeInCat = freeInCat + 1 %}{% endif %}
+      {%- endfor %}
+      <div class="cat-facts">
+        <p class="cat-facts-row">
+          <span class="cat-facts-stat"><strong>{{ listingCount }}</strong> listed</span>
+          {%- if freeInCat > 0 %}
+          <span class="cat-facts-sep">&middot;</span>
+          <span class="cat-facts-stat"><strong>{{ freeInCat }}</strong> free</span>
+          {%- endif %}
+          <span class="cat-facts-sep">&middot;</span>
+          <span class="cat-facts-stat">updated {% buildDateHuman %}</span>
+        </p>
+        <p class="cat-facts-note">New groups added most weeks — <a href="/newsletter/" data-umami-event="click-newsletter-page" data-umami-event-source="{{ page.fileSlug }}">get them by email</a> or <a href="/feed.xml">RSS</a>.</p>
       </div>
     </div>
   </div>

--- a/_includes/partials/topbar.njk
+++ b/_includes/partials/topbar.njk
@@ -12,7 +12,7 @@
               <div class="topbar-dropdown-list">
                 {%- for cat in collections.categories %}
                 {%- if cat.data.group == group.key %}
-                <a href="/{{ cat.fileSlug }}/" role="menuitem" data-umami-event="click-browse" data-umami-event-category="{{ cat.fileSlug }}">{{ cat.data.title }}{% if cat.data.groupCount > 0 %} <span class="browse-count">{{ cat.data.groupCount }}</span>{% endif %}</a>
+                <a href="/{{ cat.fileSlug }}/" role="menuitem" data-umami-event="click-browse" data-umami-event-category="{{ cat.fileSlug }}">{{ cat.data.title }}{% if cat.data.listingCount > 0 %} <span class="browse-count">{{ cat.data.listingCount }}</span>{% endif %}</a>
                 {%- endif %}
                 {%- endfor %}
               </div>

--- a/_includes/post.njk
+++ b/_includes/post.njk
@@ -70,8 +70,29 @@
   </div>
 
   <div class="page-content prose-content">
+    <nav class="post-toc" id="post-toc" aria-label="On this page" hidden>
+      <p class="post-toc-title">On this page</p>
+      <ol></ol>
+    </nav>
     {{ content | safe }}
   </div>
+  <script>
+  (function () {
+    var toc = document.getElementById('post-toc');
+    var heads = document.querySelectorAll('.prose-content > h2[id]');
+    if (!toc || heads.length < 4) return;
+    var list = toc.querySelector('ol');
+    heads.forEach(function (h) {
+      var li = document.createElement('li');
+      var a = document.createElement('a');
+      a.href = '#' + h.id;
+      a.textContent = h.textContent.replace(/#\s*$/, '').trim();
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+    toc.hidden = false;
+  })();
+  </script>
 
   {% include "partials/footer.njk" %}
 </main>

--- a/content/index.njk
+++ b/content/index.njk
@@ -75,6 +75,10 @@ permalink: /
     <div class="hp-hero-inner">
       <h1 class="hp-lede">Find your people in Vancouver.</h1>
       <p class="hp-desc">{{ totalGroups }}+ groups across {{ collections.categories.length }} categories. Run clubs, supper clubs, philosophy circles, maker spaces, and more. Browse, click through, show up.</p>
+      <a href="/about/" class="hp-origin" data-umami-event="click-origin-note">
+        <img src="/patrick-sm.jpg" alt="" width="28" height="28" loading="lazy">
+        <span>&ldquo;Vancouver can feel like a hard city to make friends. I built this to help.&rdquo; &mdash; Patrick</span>
+      </a>
       <div class="hp-search">
         <svg class="hp-search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="M16 16l5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
         <input type="text" id="homepage-group-search" class="hp-search-input" placeholder="Search {{ totalGroups }}+ groups — try &quot;hiking&quot;, &quot;chess&quot;, &quot;supper club&quot;…" autocomplete="off" data-umami-event="homepage-search">
@@ -128,8 +132,8 @@ permalink: /
         {%- if cat.data.group == group.key %}
         <a href="/{{ cat.fileSlug }}/" class="hp-cat-card" data-umami-event="click-category" data-umami-event-category="{{ cat.fileSlug }}">
           <span class="hp-cat-card-top">
-            <span class="hp-cat-name">{{ cat.data.title }}</span>
-            {% if cat.data.groupCount > 0 %}<span class="hp-cat-count">{{ cat.data.groupCount }}</span>{% endif %}
+            {% if cat.data.emoji %}<span class="hp-cat-emoji" aria-hidden="true">{{ cat.data.emoji }}</span>{% endif %}<span class="hp-cat-name">{{ cat.data.title }}</span>
+            {% if cat.data.listingCount > 0 %}<span class="hp-cat-count">{{ cat.data.listingCount }}</span>{% endif %}
           </span>
           <span class="hp-cat-desc">{{ cat.data.description | truncate(140) }}</span>
         </a>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -59,6 +59,14 @@ module.exports = function (eleventyConfig) {
       const h2s = beforeHr.match(/^## /gm);
       cat.data.groupCount = h2s ? h2s.length : 0;
 
+      // Total listings including venues (minus section headers like
+      // "Venues & Resources") — used for count badges so they match
+      // what a visitor actually sees on the page.
+      const allH2s = body.match(/^## .+$/gm) || [];
+      cat.data.listingCount = allH2s.filter(
+        (h) => !/venues?\s*(&|and)\s*(resources|spaces)/i.test(h)
+      ).length;
+
       // Extract structured group data for schema markup
       const sections = beforeHr.split(/^## /m).slice(1); // skip content before first h2
       cat.data.groupItems = sections.map((section) => {
@@ -156,11 +164,19 @@ module.exports = function (eleventyConfig) {
         if (size) metas.push('<span class="group-card-size">' + size + "</span>");
         if (metas.length)
           c += '<div class="group-card-meta">' + metas.join("") + "</div>";
-        if (url)
+        if (url) {
+          var linkLabel = "Visit";
+          try {
+            var host = new URL(url).hostname.replace(/^www\./, "");
+            if (host.length <= 28) linkLabel = host;
+          } catch (e) {}
           c +=
             '<a href="' +
             url +
-            '" class="group-card-link" target="_blank" rel="noopener noreferrer" data-umami-event="outbound-link">Visit \u2192</a>';
+            '" class="group-card-link" target="_blank" rel="noopener noreferrer" data-umami-event="outbound-link">' +
+            linkLabel +
+            " \u2192</a>";
+        }
         c += '<a class="anchor" href="#' + id + '">#</a>';
         c += "</div>";
         return c;

--- a/src/style.css
+++ b/src/style.css
@@ -316,7 +316,7 @@ main {
 
 
 .page-content {
-  max-width: 1200px;
+  max-width: 760px;
   margin: 0 auto;
   padding: 40px 32px 48px;
 }
@@ -900,7 +900,7 @@ a.hp-cat-group-label:hover { opacity: 0.8; text-decoration: none; }
 .cat-hero-main { flex: 1; min-width: 0; }
 /* Category hero reuses .hp-hero-newsletter for the newsletter card */
 .prose-hero-wrap {
-  max-width: 1200px;
+  max-width: 760px;
   margin: 0 auto;
   padding: 0 32px;
 }
@@ -2165,26 +2165,30 @@ textarea.form-input { resize: vertical; }
   to { opacity: 1; transform: translateY(0); }
 }
 
-.hp-hero { animation: fadeInUp 0.4s cubic-bezier(0.16, 1, 0.3, 1); }
+/* Entrance animations are opt-in: content must never be invisible when
+   animations don't run (crawlers, reduced-motion, paused rendering). */
+@media (prefers-reduced-motion: no-preference) {
+  .hp-hero { animation: fadeInUp 0.4s cubic-bezier(0.16, 1, 0.3, 1); }
 
-/* Staggered entrance for recently added cards */
-.recent-group { opacity: 0; animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
-.recent-group:nth-child(1) { animation-delay: 0.1s; }
-.recent-group:nth-child(2) { animation-delay: 0.18s; }
-.recent-group:nth-child(3) { animation-delay: 0.26s; }
-.recent-group:nth-child(4) { animation-delay: 0.34s; }
+  /* Staggered entrance for recently added cards */
+  .recent-group { opacity: 0; animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+  .recent-group:nth-of-type(1) { animation-delay: 0.1s; }
+  .recent-group:nth-of-type(2) { animation-delay: 0.18s; }
+  .recent-group:nth-of-type(3) { animation-delay: 0.26s; }
+  .recent-group:nth-of-type(4) { animation-delay: 0.34s; }
 
-/* Staggered entrance for category groups */
-.hp-cat-group { opacity: 0; animation: fadeInUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
-.hp-cat-group:nth-child(1) { animation-delay: 0.05s; }
-.hp-cat-group:nth-child(2) { animation-delay: 0.1s; }
-.hp-cat-group:nth-child(3) { animation-delay: 0.15s; }
-.hp-cat-group:nth-child(4) { animation-delay: 0.2s; }
-.hp-cat-group:nth-child(5) { animation-delay: 0.25s; }
-.hp-cat-group:nth-child(6) { animation-delay: 0.3s; }
-.hp-cat-group:nth-child(7) { animation-delay: 0.35s; }
+  /* Staggered entrance for category groups */
+  .hp-cat-group { opacity: 0; animation: fadeInUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+  .hp-cat-group:nth-of-type(1) { animation-delay: 0.05s; }
+  .hp-cat-group:nth-of-type(2) { animation-delay: 0.1s; }
+  .hp-cat-group:nth-of-type(3) { animation-delay: 0.15s; }
+  .hp-cat-group:nth-of-type(4) { animation-delay: 0.2s; }
+  .hp-cat-group:nth-of-type(5) { animation-delay: 0.25s; }
+  .hp-cat-group:nth-of-type(6) { animation-delay: 0.3s; }
+  .hp-cat-group:nth-of-type(7) { animation-delay: 0.35s; }
 
-.builder-card { animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both; }
+  .builder-card { animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both; }
+}
 
 .edit-modal[style*="block"] .edit-modal-inner {
   animation: fadeInUp 0.25s ease-out;
@@ -2248,9 +2252,10 @@ textarea.form-input { resize: vertical; }
   .hp-cat-card { padding: 12px 14px; }
   .hp-cat-desc { display: none; }
 
-  /* Collapse category groups beyond 3rd on mobile */
-  .hp-cat-group:nth-child(n+4) { display: none; }
-  .hp-cat-group:nth-child(n+4).show { display: block; }
+  /* Collapse category groups beyond 3rd on mobile
+     (nth-of-type: the section-title <p> is the first child) */
+  .hp-cat-group:nth-of-type(n+4) { display: none; }
+  .hp-cat-group:nth-of-type(n+4).show { display: block; }
   .hp-show-all-cats { display: block; }
 
   .cat-hero { padding: 24px 0 20px; }
@@ -2425,4 +2430,108 @@ textarea.form-input { resize: vertical; }
   margin: 10px 0 0;
   font-size: 0.82em;
   color: var(--text-muted);
+}
+
+/* ========================================
+   DESIGN BATCH — origin note, card emoji, category facts, post TOC
+   ======================================== */
+.hp-origin {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 18px;
+  text-decoration: none !important;
+  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.95em;
+}
+.hp-origin img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.hp-origin:hover span { color: var(--accent); }
+.hp-origin:visited { color: var(--text-muted); }
+
+.hp-cat-emoji {
+  font-size: 0.9em;
+  margin-right: 2px;
+  opacity: 0.85;
+}
+
+.cat-facts {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 22px;
+  width: 320px;
+  flex-shrink: 0;
+  align-self: center;
+}
+.cat-facts-row {
+  margin: 0 0 8px;
+  font-size: 0.9em;
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+}
+.cat-facts-stat strong {
+  font-family: var(--font-display);
+  font-size: 1.25em;
+  font-weight: 600;
+  color: var(--text);
+}
+.cat-facts-sep { color: var(--text-muted); }
+.cat-facts-note {
+  margin: 0;
+  font-size: 0.82em;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+.cat-facts-note a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+@media (max-width: 900px) {
+  .cat-facts { width: 100%; align-self: stretch; }
+}
+
+.post-toc {
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  margin-bottom: 28px;
+  max-width: 640px;
+}
+.post-toc-title {
+  font-size: 0.72em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+}
+.post-toc ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  columns: 2;
+  column-gap: 24px;
+}
+.post-toc li { margin: 3px 0; break-inside: avoid; }
+.post-toc a {
+  color: var(--accent);
+  font-size: 0.9em;
+  text-decoration: none;
+}
+.post-toc a:hover { text-decoration: underline; text-underline-offset: 2px; }
+@media (max-width: 640px) {
+  .post-toc ol { columns: 1; }
 }


### PR DESCRIPTION
Five approved design/UI improvements, verified with before/after screenshots at 1440px and 390px.

- **One newsletter form per page.** Category-page heroes had a full signup form (plus the footer form, plus the homepage one). Replaced with a category facts card — "18 listed · 4 free · updated July 2026" with email/RSS links — which is more useful and less product-y.
- **Honest count badges.** Homepage/browse-dropdown badges now use a new `listingCount` (all listings minus section headers), so Karaoke no longer shows "1" next to a description that says "8 karaoke spots."
- **Group cards show the destination domain** ("socialrunclub.com →") instead of an anonymous "Visit →" — better link scent for a site whose product is outbound links. Falls back to "Visit" for hosts over 28 chars.
- **Homepage warmth**: category emoji (already in frontmatter, previously unused) on every card, and the origin note — Patrick's photo + "Vancouver can feel like a hard city to make friends. I built this to help." — under the hero, linking to /about/.
- **Blog readability**: prose column centered at 760px (was left-stranded in a 1200px container) and a client-side "On this page" TOC for posts with 4+ sections.
- **Bug fixes**: entrance animations (`opacity: 0` + fadeInUp) are now wrapped in `@media (prefers-reduced-motion: no-preference)` so content is never invisible when animations don't run (crawlers, preview bots, reduced-motion users). The stagger and mobile-collapse selectors used `nth-child` but the section title is the first child — corrected to `nth-of-type`, so mobile shows 3 category groups as intended instead of 2.

Verified: clean build, facts card and domain labels render correctly on category pages, TOC renders on both guides, mobile homepage shows all content with 3 groups above the "Show all" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_