### PR TITLE
Remove emoji from homepage cards, related categories, and /free/ headings

### DIFF
--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -180,7 +180,7 @@
     <div class="start-groups">
       {%- for cat in relatedCats %}
       <a href="/{{ cat.fileSlug }}/" class="start-group-card" data-umami-event="click-related-category" data-umami-event-category="{{ cat.fileSlug }}">
-        <span class="start-group-name">{{ cat.data.emoji }} {{ cat.data.title }}</span>
+        <span class="start-group-name">{{ cat.data.title }}</span>
         <span class="start-group-desc">{{ cat.data.description | truncate(100) }}</span>
       </a>
       {%- endfor %}

--- a/content/free.njk
+++ b/content/free.njk
@@ -88,7 +88,7 @@ eleventyExcludeFromCollections: true
     {%- endfor %}
     {%- if catFree.length %}
     <section class="start-section">
-      <h2 class="start-section-title">{{ cat.data.emoji }} <a href="/{{ cat.fileSlug }}/">{{ cat.data.title }}</a></h2>
+      <h2 class="start-section-title"><a href="/{{ cat.fileSlug }}/">{{ cat.data.title }}</a></h2>
       <div class="start-groups">
         {%- for item in catFree %}
         <a href="/{{ cat.fileSlug }}/#{{ item.name | mdAnchor }}" class="start-group-card" data-umami-event="click-free-group" data-umami-event-category="{{ cat.fileSlug }}">

--- a/content/index.njk
+++ b/content/index.njk
@@ -132,7 +132,7 @@ permalink: /
         {%- if cat.data.group == group.key %}
         <a href="/{{ cat.fileSlug }}/" class="hp-cat-card" data-umami-event="click-category" data-umami-event-category="{{ cat.fileSlug }}">
           <span class="hp-cat-card-top">
-            {% if cat.data.emoji %}<span class="hp-cat-emoji" aria-hidden="true">{{ cat.data.emoji }}</span>{% endif %}<span class="hp-cat-name">{{ cat.data.title }}</span>
+            <span class="hp-cat-name">{{ cat.data.title }}</span>
             {% if cat.data.listingCount > 0 %}<span class="hp-cat-count">{{ cat.data.listingCount }}</span>{% endif %}
           </span>
           <span class="hp-cat-desc">{{ cat.data.description | truncate(140) }}</span>

--- a/src/style.css
+++ b/src/style.css
@@ -2456,12 +2456,6 @@ textarea.form-input { resize: vertical; }
 .hp-origin:hover span { color: var(--accent); }
 .hp-origin:visited { color: var(--text-muted); }
 
-.hp-cat-emoji {
-  font-size: 0.9em;
-  margin-right: 2px;
-  opacity: 0.85;
-}
-
 .cat-facts {
   background: var(--bg-card);
   border: 1px solid var(--border);


### PR DESCRIPTION
Reverts the emoji added to card UI in #133 — 40 emoji in the homepage grid read as clutter rather than warmth. Emoji stay in category frontmatter (still used by the newsletter spotlight) but no longer render on homepage cards, the related-categories block, or `/free/` section headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_