### PR TITLE
[Draft/proposal] Design: 'cozy paper' warmth pass

### DIFF
--- a/_includes/partials/topbar.njk
+++ b/_includes/partials/topbar.njk
@@ -1,12 +1,6 @@
 <nav class="topbar" id="topbar">
   <div class="topbar-inner">
-    <a href="/" class="topbar-logo" aria-label="Vancouver Community — home">
-      <svg class="topbar-mark" width="30" height="30" viewBox="0 0 64 64" aria-hidden="true">
-        <rect width="64" height="64" rx="16" fill="var(--accent)"/>
-        <text x="32" y="46" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-size="36" font-style="italic" font-weight="500" fill="#FAF8F5" letter-spacing="-3">vc</text>
-      </svg>
-      <span class="topbar-wordmark"><span class="topbar-logo-van">Vancouver</span> <span class="topbar-logo-com">Community</span></span>
-    </a>
+    <a href="/" class="topbar-logo"><span class="topbar-logo-van">Vancouver</span> <span class="topbar-logo-com">Community</span></a>
     <div class="topbar-actions">
       <div class="topbar-browse" id="topbar-browse">
         <button class="topbar-browse-btn" aria-expanded="false" aria-controls="topbar-dropdown">Browse <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>

--- a/_includes/partials/topbar.njk
+++ b/_includes/partials/topbar.njk
@@ -1,6 +1,12 @@
 <nav class="topbar" id="topbar">
   <div class="topbar-inner">
-    <a href="/" class="topbar-logo"><span class="topbar-logo-van">Vancouver</span> <span class="topbar-logo-com">Community</span></a>
+    <a href="/" class="topbar-logo" aria-label="Vancouver Community — home">
+      <svg class="topbar-mark" width="30" height="30" viewBox="0 0 64 64" aria-hidden="true">
+        <rect width="64" height="64" rx="16" fill="var(--accent)"/>
+        <text x="32" y="46" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-size="36" font-style="italic" font-weight="500" fill="#FAF8F5" letter-spacing="-3">vc</text>
+      </svg>
+      <span class="topbar-wordmark"><span class="topbar-logo-van">Vancouver</span> <span class="topbar-logo-com">Community</span></span>
+    </a>
     <div class="topbar-actions">
       <div class="topbar-browse" id="topbar-browse">
         <button class="topbar-browse-btn" aria-expanded="false" aria-controls="topbar-dropdown">Browse <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true"><path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>

--- a/content/index.njk
+++ b/content/index.njk
@@ -73,7 +73,7 @@ permalink: /
   <div class="hp-hero">
     <div class="hp-hero-wrap">
     <div class="hp-hero-inner">
-      <h1 class="hp-lede">Find your people in Vancouver.</h1>
+      <h1 class="hp-lede">Find your <span class="hand-underline">people</span> in Vancouver.</h1>
       <p class="hp-desc">{{ totalGroups }}+ groups across {{ collections.categories.length }} categories. Run clubs, supper clubs, philosophy circles, maker spaces, and more. Browse, click through, show up.</p>
       <a href="/about/" class="hp-origin" data-umami-event="click-origin-note">
         <img src="/patrick-sm.jpg" alt="" width="28" height="28" loading="lazy">

--- a/src/style.css
+++ b/src/style.css
@@ -97,24 +97,12 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
 .topbar-logo {
   text-decoration: none;
   display: flex;
-  align-items: center;
-  gap: 9px;
-  line-height: 1;
-}
-.topbar-logo:hover { text-decoration: none; }
-.topbar-logo:visited { color: var(--text); }
-.topbar-mark {
-  flex-shrink: 0;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(168, 90, 70, 0.25);
-  transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.topbar-logo:hover .topbar-mark { transform: rotate(-4deg); }
-.topbar-wordmark {
-  display: flex;
   align-items: baseline;
   gap: 5px;
+  line-height: 1;
 }
+.topbar-logo:hover { text-decoration: none; opacity: 0.85; }
+.topbar-logo:visited { color: var(--text); }
 .topbar-logo-van {
   font-family: var(--font-display);
   font-size: 1.2em;
@@ -126,7 +114,6 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-family: var(--font-display);
   font-size: 1.2em;
   font-weight: 600;
-  font-style: italic;
   color: var(--accent);
 }
 
@@ -147,7 +134,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   padding: 7px 14px;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
   font-family: inherit;
   font-size: 0.88em;
   font-weight: 500;
@@ -245,7 +232,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-weight: 500;
   color: var(--text-on-accent);
   background: var(--accent);
-  border-radius: 8px;
+  border-radius: 6px;
   text-decoration: none;
   transition: background 0.15s;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2570,3 +2570,41 @@ textarea.form-input { resize: vertical; }
   font-size: 0.9em;
   color: var(--text-muted);
 }
+
+/* ==========================================================================
+   PROTOTYPE — "cozy paper" warmth pass (design proposal, reversible)
+   ========================================================================== */
+:root { --bg-card: #FFFDF9; } /* was #fff — a hair of cream, reads as paper */
+
+/* Faint paper grain over the whole page — barely perceptible, adds warmth */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
+}
+
+/* Hand-drawn underline under "people" in the hero — homemade, on-brand */
+.hand-underline {
+  position: relative;
+  white-space: nowrap;
+}
+.hand-underline::after {
+  content: "";
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  bottom: -0.12em;
+  height: 0.32em;
+  background: no-repeat center/100% 100%
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='16' viewBox='0 0 200 16' preserveAspectRatio='none'%3E%3Cpath d='M3 9 Q 40 3 80 8 T 160 7 Q 180 8 197 5' stroke='%23A85A46' stroke-width='3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  opacity: 0.85;
+}
+
+/* Cards feel a touch more like paper pinned to a board */
+.group-card, .hp-cat-card, .start-group-card, .recent-group {
+  box-shadow: 0 1px 2px rgba(44,41,37,0.04), 0 2px 8px rgba(44,41,37,0.03);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -115,6 +115,24 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-size: 1.2em;
   font-weight: 600;
   color: var(--accent);
+  position: relative;
+}
+/* Hand-drawn flourish under "Community" — the same hand as the hero underline */
+.topbar-logo-com::after {
+  content: "";
+  position: absolute;
+  left: -1px;
+  right: -2px;
+  bottom: -0.17em;
+  height: 0.26em;
+  background: no-repeat center/100% 100%
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='10' viewBox='0 0 120 10' preserveAspectRatio='none'%3E%3Cpath d='M2 6 Q 32 2 62 5 T 118 4' stroke='%23A85A46' stroke-width='2.4' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  opacity: 0.8;
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.2s ease;
+}
+.topbar-logo:hover .topbar-logo-com::after {
+  opacity: 1;
+  transform: translateY(1px);
 }
 
 .topbar-actions {
@@ -134,7 +152,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   padding: 7px 14px;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   font-family: inherit;
   font-size: 0.88em;
   font-weight: 500;
@@ -232,7 +250,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-weight: 500;
   color: var(--text-on-accent);
   background: var(--accent);
-  border-radius: 6px;
+  border-radius: 8px;
   text-decoration: none;
   transition: background 0.15s;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -97,12 +97,24 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
 .topbar-logo {
   text-decoration: none;
   display: flex;
-  align-items: baseline;
-  gap: 5px;
+  align-items: center;
+  gap: 9px;
   line-height: 1;
 }
-.topbar-logo:hover { text-decoration: none; opacity: 0.85; }
+.topbar-logo:hover { text-decoration: none; }
 .topbar-logo:visited { color: var(--text); }
+.topbar-mark {
+  flex-shrink: 0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(168, 90, 70, 0.25);
+  transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.topbar-logo:hover .topbar-mark { transform: rotate(-4deg); }
+.topbar-wordmark {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+}
 .topbar-logo-van {
   font-family: var(--font-display);
   font-size: 1.2em;
@@ -114,6 +126,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-family: var(--font-display);
   font-size: 1.2em;
   font-weight: 600;
+  font-style: italic;
   color: var(--accent);
 }
 
@@ -134,7 +147,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   padding: 7px 14px;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   font-family: inherit;
   font-size: 0.88em;
   font-weight: 500;
@@ -232,7 +245,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
   font-weight: 500;
   color: var(--text-on-accent);
   background: var(--accent);
-  border-radius: 6px;
+  border-radius: 8px;
   text-decoration: none;
   transition: background 0.15s;
 }


### PR DESCRIPTION
**Design proposal — awaiting sign-off. Do not merge without a design decision.**

The site is already tasteful and warm; what it lacks is the *distinctive* character the brand asks for ("hand-typeset zine / well-loved bulletin board"). This adds warmth through texture and typography, not decoration.

Three moves:
1. **Hand-drawn underline under "people"** in the hero headline — the signature homemade touch; reinforces the copy.
2. **Faint page-wide paper grain** — barely perceptible, warms everything off flat white.
3. **Warmer paper card background** (`#FFFDF9`) + softer paper shadows.

CSS + one line of HTML; fully reversible. Deliberately avoids loud colour, stock photos, illustration, and gradients (the emoji lesson).

Before/after screenshots shared with the maintainer in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_