### PR TITLE
Remove the Patrick origin quote from the homepage hero

### DIFF
--- a/content/index.njk
+++ b/content/index.njk
@@ -75,10 +75,6 @@ permalink: /
     <div class="hp-hero-inner">
       <h1 class="hp-lede">Find your <span class="hand-underline">people</span> in Vancouver.</h1>
       <p class="hp-desc">{{ totalGroups }}+ groups across {{ collections.categories.length }} categories. Run clubs, supper clubs, philosophy circles, maker spaces, and more. Browse, click through, show up.</p>
-      <a href="/about/" class="hp-origin" data-umami-event="click-origin-note">
-        <img src="/patrick-sm.jpg" alt="" width="28" height="28" loading="lazy">
-        <span>&ldquo;Vancouver can feel like a hard city to make friends. I built this to help.&rdquo; &mdash; Patrick</span>
-      </a>
       <div class="hp-search">
         <svg class="hp-search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="M16 16l5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
         <input type="text" id="homepage-group-search" class="hp-search-input" placeholder="Search {{ totalGroups }}+ groups — try &quot;hiking&quot;, &quot;chess&quot;, &quot;supper club&quot;…" autocomplete="off" data-umami-event="homepage-search">

--- a/src/style.css
+++ b/src/style.css
@@ -2451,29 +2451,8 @@ textarea.form-input { resize: vertical; }
 }
 
 /* ========================================
-   DESIGN BATCH — origin note, card emoji, category facts, post TOC
+   DESIGN BATCH — category facts, post TOC
    ======================================== */
-.hp-origin {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 18px;
-  text-decoration: none !important;
-  color: var(--text-muted);
-  font-family: var(--font-display);
-  font-style: italic;
-  font-size: 0.95em;
-}
-.hp-origin img {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-  flex-shrink: 0;
-}
-.hp-origin:hover span { color: var(--accent); }
-.hp-origin:visited { color: var(--text-muted); }
-
 .cat-facts {
   background: var(--bg-card);
   border: 1px solid var(--border);


### PR DESCRIPTION
Removes the founder quote + avatar (“Vancouver can feel like a hard city to make friends. I built this to help.” — Patrick) from under the homepage hero lede, plus the now-unused `.hp-origin` CSS. Hero headline, underline, and search are unchanged.

Branch was restarted fresh from `main` to avoid the history drift flagged on the last design PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_