### PR TITLE
Ad inventory: self-selling open sponsor slots + homepage partner slot

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -1,5 +1,5 @@
 {
-  "_docs": "Category sponsors. Each listing renders a labeled 'Community sponsor' card at the top of its category page. Fields: category (file slug, e.g. 'pottery-ceramics'), name, description (1-2 sentences, written in the site's voice), url, where (optional neighbourhood), cta (optional link text, defaults to 'Visit'). Sold via /advertise/. Keep it to one sponsor per category.",
+  "_docs": "Sponsors. 'listings' = per-category sponsors, each rendering a labeled 'Community sponsor' card atop its category page (fields: category (file slug), name, description, url, where (optional), cta (optional, defaults 'Visit')); one per category. 'homepage' = optional single site-wide partner on the homepage (same fields minus category). Empty category slots and an empty homepage slot auto-render a labeled 'open' placeholder linking to /advertise/. Sold via /advertise/.",
   "_example": {
     "category": "pottery-ceramics",
     "name": "Example Clay Studio",
@@ -8,5 +8,6 @@
     "where": "Mount Pleasant",
     "cta": "See class times"
   },
+  "homepage": null,
   "listings": []
 }

--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -161,11 +161,17 @@
       {%- endif %}
       <a href="{{ sponsor.url }}" class="group-card-link" target="_blank" rel="sponsored noopener noreferrer" data-umami-event="sponsor-click" data-umami-event-category="{{ page.fileSlug }}">{{ sponsor.cta or "Visit" }} &rarr;</a>
     </div>
+    {%- else %}
+    <a href="/advertise/" class="sponsor-card sponsor-card-open" data-umami-event="click-advertise" data-umami-event-source="{{ page.fileSlug }}">
+      <span class="sponsor-card-label">Sponsor slot &middot; open</span>
+      <div class="group-card-header">
+        <h2>Your {{ title | lower }} business here</h2>
+      </div>
+      <p class="group-card-desc">Reach people searching for {{ title | lower }} in Vancouver this week — the exact crowd you want. Community groups stay free; sponsors keep it that way.</p>
+      <span class="sponsor-card-link">Feature it &middot; from $39/mo &rarr;</span>
+    </a>
     {%- endif %}
     {{ content | stripH1 | cardify | safe }}
-    {%- if not sponsor %}
-    <p class="sponsor-slot-note">Run a studio, shop, or business this crowd would love? <a href="/advertise/" data-umami-event="click-advertise" data-umami-event-source="{{ page.fileSlug }}">Feature it here</a> — it helps keep the directory free.</p>
-    {%- endif %}
   </div>
 
   {%- set relatedCats = [] %}

--- a/_includes/category.njk
+++ b/_includes/category.njk
@@ -105,6 +105,15 @@
       {%- endif %}
     {%- endfor %}
   {%- endfor %}
+  {%- set sponsor = null %}
+  {%- for s in sponsors.listings %}
+    {%- if s.category == page.fileSlug %}{% set sponsor = s %}{% endif %}
+  {%- endfor %}
+  {%- set freeInCat = 0 %}
+  {%- for item in groupItems %}
+    {%- if item.free %}{% set freeInCat = freeInCat + 1 %}{% endif %}
+  {%- endfor %}
+
   <div class="cat-hero">
     <div class="cat-hero-wrap">
       <div class="cat-hero-main">
@@ -115,6 +124,9 @@
         </div>
         <h1 class="cat-title">{{ title }}{% if not titleHasGroupWord %} Groups{% endif %} in Vancouver</h1>
         <p class="cat-desc">{{ description }}</p>
+        <p class="cat-facts-inline">
+          <strong>{{ listingCount }}</strong> listed{% if freeInCat > 0 %} &middot; <strong>{{ freeInCat }}</strong> free{% endif %} &middot; updated {% buildDateHuman %} &middot; <a href="/newsletter/" data-umami-event="click-newsletter-page" data-umami-event-source="{{ page.fileSlug }}">get new ones by email</a>
+        </p>
         <div class="cat-actions">
           <a href="/submit/" data-umami-event="click-submit-cta" data-umami-event-source="{{ page.fileSlug }}">Add a group</a>
           <span class="hp-sep">&middot;</span>
@@ -124,53 +136,28 @@
           <span id="page-views" class="cat-views"></span>
         </div>
       </div>
-      {%- set freeInCat = 0 %}
-      {%- for item in groupItems %}
-        {%- if item.free %}{% set freeInCat = freeInCat + 1 %}{% endif %}
-      {%- endfor %}
-      <div class="cat-facts">
-        <p class="cat-facts-row">
-          <span class="cat-facts-stat"><strong>{{ listingCount }}</strong> listed</span>
-          {%- if freeInCat > 0 %}
-          <span class="cat-facts-sep">&middot;</span>
-          <span class="cat-facts-stat"><strong>{{ freeInCat }}</strong> free</span>
-          {%- endif %}
-          <span class="cat-facts-sep">&middot;</span>
-          <span class="cat-facts-stat">updated {% buildDateHuman %}</span>
-        </p>
-        <p class="cat-facts-note">New groups added most weeks — <a href="/newsletter/" data-umami-event="click-newsletter-page" data-umami-event-source="{{ page.fileSlug }}">get them by email</a> or <a href="/feed.xml">RSS</a>.</p>
+      {%- if sponsor %}
+      <div class="sponsor-card sponsor-card-hero">
+        <span class="sponsor-card-label">Community sponsor</span>
+        <div class="group-card-header"><h2>{{ sponsor.name }}</h2></div>
+        <p class="group-card-desc">{{ sponsor.description }}</p>
+        {%- if sponsor.where %}
+        <div class="group-card-meta"><span class="group-card-where">&#128205; {{ sponsor.where }}</span></div>
+        {%- endif %}
+        <a href="{{ sponsor.url }}" class="group-card-link" target="_blank" rel="sponsored noopener noreferrer" data-umami-event="sponsor-click" data-umami-event-category="{{ page.fileSlug }}">{{ sponsor.cta or "Visit" }} &rarr;</a>
       </div>
+      {%- else %}
+      <a href="/advertise/" class="sponsor-card sponsor-card-hero sponsor-card-open" data-umami-event="click-advertise" data-umami-event-source="{{ page.fileSlug }}">
+        <span class="sponsor-card-label">Sponsor slot &middot; open</span>
+        <div class="group-card-header"><h2>Your {{ title | lower }} business here</h2></div>
+        <p class="group-card-desc">Reach people searching for {{ title | lower }} in Vancouver this week. Community groups stay free; sponsors keep it that way.</p>
+        <span class="sponsor-card-link">Feature it &middot; from $39/mo &rarr;</span>
+      </a>
+      {%- endif %}
     </div>
   </div>
 
-  {%- set sponsor = null %}
-  {%- for s in sponsors.listings %}
-    {%- if s.category == page.fileSlug %}{% set sponsor = s %}{% endif %}
-  {%- endfor %}
-
   <div class="category-entries">
-    {%- if sponsor %}
-    <div class="sponsor-card">
-      <span class="sponsor-card-label">Community sponsor</span>
-      <div class="group-card-header">
-        <h2>{{ sponsor.name }}</h2>
-      </div>
-      <p class="group-card-desc">{{ sponsor.description }}</p>
-      {%- if sponsor.where %}
-      <div class="group-card-meta"><span class="group-card-where">&#128205; {{ sponsor.where }}</span></div>
-      {%- endif %}
-      <a href="{{ sponsor.url }}" class="group-card-link" target="_blank" rel="sponsored noopener noreferrer" data-umami-event="sponsor-click" data-umami-event-category="{{ page.fileSlug }}">{{ sponsor.cta or "Visit" }} &rarr;</a>
-    </div>
-    {%- else %}
-    <a href="/advertise/" class="sponsor-card sponsor-card-open" data-umami-event="click-advertise" data-umami-event-source="{{ page.fileSlug }}">
-      <span class="sponsor-card-label">Sponsor slot &middot; open</span>
-      <div class="group-card-header">
-        <h2>Your {{ title | lower }} business here</h2>
-      </div>
-      <p class="group-card-desc">Reach people searching for {{ title | lower }} in Vancouver this week — the exact crowd you want. Community groups stay free; sponsors keep it that way.</p>
-      <span class="sponsor-card-link">Feature it &middot; from $39/mo &rarr;</span>
-    </a>
-    {%- endif %}
     {{ content | stripH1 | cardify | safe }}
   </div>
 

--- a/content/index.njk
+++ b/content/index.njk
@@ -118,6 +118,29 @@ permalink: /
   </section>
   {%- endif %}
 
+  {%- if sponsors.homepage and sponsors.homepage.name %}
+  <section class="hp-section">
+    <div class="sponsor-card sponsor-card-wide">
+      <span class="sponsor-card-label">Community partner</span>
+      <div class="group-card-header"><h2>{{ sponsors.homepage.name }}</h2></div>
+      <p class="group-card-desc">{{ sponsors.homepage.description }}</p>
+      {%- if sponsors.homepage.where %}
+      <div class="group-card-meta"><span class="group-card-where">&#128205; {{ sponsors.homepage.where }}</span></div>
+      {%- endif %}
+      <a href="{{ sponsors.homepage.url }}" class="group-card-link" target="_blank" rel="sponsored noopener noreferrer" data-umami-event="sponsor-click" data-umami-event-category="homepage">{{ sponsors.homepage.cta or "Visit" }} &rarr;</a>
+    </div>
+  </section>
+  {%- else %}
+  <section class="hp-section">
+    <a href="/advertise/" class="sponsor-card sponsor-card-wide sponsor-card-open" data-umami-event="click-advertise" data-umami-event-source="homepage">
+      <span class="sponsor-card-label">Community partner &middot; slot open</span>
+      <div class="group-card-header"><h2>Reach everyone starting their search here</h2></div>
+      <p class="group-card-desc">This is the front door — the most-visited page on the directory. One partner at a time, clearly labeled, right where Vancouver looks for things to do. Sponsors keep the whole directory free.</p>
+      <span class="sponsor-card-link">Become a partner &rarr;</span>
+    </a>
+  </section>
+  {%- endif %}
+
   <section class="hp-section" id="categories">
     <p class="hp-section-title">Browse {{ totalGroups }}+ groups</p>
     {%- for group in groups %}

--- a/src/style.css
+++ b/src/style.css
@@ -2364,6 +2364,28 @@ textarea.form-input { resize: vertical; }
   max-width: none;
 }
 
+/* Hero variant — sponsor sits in the category hero aside (prime placement) */
+.sponsor-card-hero {
+  width: 340px;
+  flex-shrink: 0;
+  align-self: flex-start;
+  max-width: 340px;
+  background: var(--bg-card);
+}
+.sponsor-card-hero.sponsor-card-open { background: transparent; }
+@media (max-width: 900px) {
+  .sponsor-card-hero { width: 100%; max-width: none; }
+}
+
+/* Slim facts line under the category description (freed the hero aside) */
+.cat-facts-inline {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  margin: 10px 0 0;
+}
+.cat-facts-inline strong { color: var(--text-secondary); font-weight: 600; }
+.cat-facts-inline a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
+
 /* Open/available state — an empty slot that sells itself. Warm dashed
    placeholder styled like a real sponsor card so a business can picture it. */
 .sponsor-card-open {
@@ -2477,45 +2499,6 @@ textarea.form-input { resize: vertical; }
 /* ========================================
    DESIGN BATCH — category facts, post TOC
    ======================================== */
-.cat-facts {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 18px 22px;
-  width: 320px;
-  flex-shrink: 0;
-  align-self: center;
-}
-.cat-facts-row {
-  margin: 0 0 8px;
-  font-size: 0.9em;
-  color: var(--text-secondary);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: baseline;
-}
-.cat-facts-stat strong {
-  font-family: var(--font-display);
-  font-size: 1.25em;
-  font-weight: 600;
-  color: var(--text);
-}
-.cat-facts-sep { color: var(--text-muted); }
-.cat-facts-note {
-  margin: 0;
-  font-size: 0.82em;
-  line-height: 1.5;
-  color: var(--text-muted);
-}
-.cat-facts-note a {
-  color: var(--accent);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-@media (max-width: 900px) {
-  .cat-facts { width: 100%; align-self: stretch; }
-}
 
 .post-toc {
   background: var(--bg-warm);

--- a/src/style.css
+++ b/src/style.css
@@ -2352,17 +2352,41 @@ textarea.form-input { resize: vertical; }
   padding: 0;
   margin: 0;
 }
-.sponsor-slot-note {
-  grid-column: 1 / -1;
-  margin-top: 8px;
-  font-size: 0.85em;
-  color: var(--text-muted);
-}
-.sponsor-slot-note a {
+.sponsor-card-link {
+  font-size: 0.9em;
+  font-weight: 500;
   color: var(--accent);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  margin-top: 2px;
 }
+
+/* Wide variant — homepage partner slot spans its section */
+.sponsor-card-wide {
+  max-width: none;
+}
+
+/* Open/available state — an empty slot that sells itself. Warm dashed
+   placeholder styled like a real sponsor card so a business can picture it. */
+.sponsor-card-open {
+  background: transparent;
+  border-style: dashed;
+  border-left-width: 3px;
+  border-color: var(--accent-underline);
+  border-left-color: var(--accent);
+  text-decoration: none !important;
+  transition: border-color 0.15s, background 0.15s, transform 0.15s;
+}
+.sponsor-card-open:visited { color: inherit; }
+.sponsor-card-open:hover {
+  background: var(--bg-warm);
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+.sponsor-card-open .sponsor-card-label { color: var(--text-muted); }
+.sponsor-card-open:hover .sponsor-card-label { color: var(--accent); }
+.sponsor-card-open .group-card-header h2 { color: var(--text-secondary); font-weight: 500; }
+.sponsor-card-open:hover .group-card-header h2 { color: var(--text); }
+.sponsor-card-open .sponsor-card-link { transition: transform 0.15s; }
+.sponsor-card-open:hover .sponsor-card-link { transform: translateX(3px); }
 
 .advertise-tiers {
   display: grid;


### PR DESCRIPTION
Makes the ad inventory visible and places it where the traffic is — while keeping the homegrown feel.

- **Self-selling open category slots.** An unsold category used to show a tiny grey line. It now renders a warm, clearly-labeled "open slot" placeholder styled like a real sponsor card, with category-specific copy and price ("Your book clubs business here · Reach people searching for book clubs in Vancouver · from $39/mo →"). Every empty category now advertises the slot automatically.
- **Homepage community-partner slot.** The highest-traffic page had zero ad inventory; now there's a single premium slot between "Recently added" and the category grid.
- **One reusable component**, filled/open + wide variants, all driven by `_data/sponsors.json` (new optional `homepage` entry). Sold slot → warm labeled card; empty → the self-selling placeholder.

Not yet built (follow-ups): `/advertise` conversion redesign, neighbourhood sponsor tier, optional Stripe self-serve.

Draft pending design sign-off — preview on the branch URL before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_