### PR TITLE
Add 3 SEO guides for top-traffic themes (book clubs, supper clubs, language exchange)

### DIFF
--- a/content/blog/best-book-clubs-in-vancouver.md
+++ b/content/blog/best-book-clubs-in-vancouver.md
@@ -1,0 +1,52 @@
+---
+layout: post
+tags: post
+title: "The best book clubs in Vancouver (for every kind of reader)"
+description: "Silent book clubs, women's reading circles, sci-fi and fantasy groups, library clubs — a guide to finding a Vancouver book club you'll actually keep going to."
+date: 2026-07-09
+faq:
+  - q: "How do I find a book club in Vancouver?"
+    a: "Start with the type of reader you are: silent book clubs for introverts, discussion clubs for debaters, genre clubs for sci-fi or literary readers, and free library-run clubs at Vancouver Public Library. The Vancouver Community Directory lists active book clubs across all of these on its book clubs page."
+  - q: "Are there free book clubs in Vancouver?"
+    a: "Yes — Vancouver Public Library runs free book clubs at branches across the city, and Silent Book Club meetups are free to attend (you just buy your own drink). Most community book clubs cost nothing beyond the book itself."
+  - q: "What is a silent book club?"
+    a: "A silent book club is a gathering where people bring their own book, read quietly together for an hour or so at a pub or café, and then chat if they feel like it. There's no assigned reading and no pressure to talk — it's ideal for introverts and anyone who finds traditional book clubs stressful."
+  - q: "How do I meet people through a book club in Vancouver?"
+    a: "Pick a club that meets on a regular schedule and go three times before deciding. Book clubs are one of the easiest ways to make friends in Vancouver because they give you a built-in reason to talk and a recurring group of the same faces."
+---
+
+A good book club is one of the best social deals in Vancouver: a standing reason to leave the house, a room of people who like at least one thing you like, and a conversation that's already started for you. The trick is finding the *right* one — because "book club" covers everything from silent reading in a pub to a heated debate about a novel nobody finished.
+
+Here's how to find one you'll actually keep going to, organized by the kind of reader you are. Every group below is a real, active Vancouver club from [the directory's book clubs page](/book-clubs/).
+
+## If you're an introvert (or book clubs stress you out)
+
+**[Silent Book Club](/book-clubs/#silent-book-club)** is the cult favourite for a reason. Everyone brings their own book, you read quietly together for an hour, and then you chat only if you want to. No assigned reading, no "did you finish it?" guilt, no one dominating the discussion. It's the lowest-pressure social event in the city — you're technically just reading alone, but in good company. Introverts, this is your club.
+
+## If you want real discussion
+
+Some people come for the books; some come for the argument. If that's you:
+
+- **[Rebel Book Club Vancouver](/book-clubs/#rebel-book-club-vancouver)** picks thought-provoking non-fiction and builds a proper discussion around it.
+- **[Vancouver Unconventional Books](/book-clubs/#vancouver-unconventional-books)** goes off the beaten path — literary, iconoclastic picks for people who've read the bestsellers already.
+- **[Vancouver Women Who Read](/book-clubs/#vancouver-women-who-read)** is an "anti-book club": everyone reads their *own* thought-provoking choice and brings it to the table, so every meetup is a fresh set of recommendations.
+
+## If you read a specific genre
+
+- **[Vancouver Fantasy & Sci-Fi Group](/book-clubs/#vancouver-fantasy-%26-sci-fi-group)** discusses speculative fiction — books, film, anime — through the big human questions underneath. No lore-flexing, no gatekeeping.
+- **[The Little Things Book and Movie Club](/book-clubs/#the-little-things-book-and-movie-club)** pairs books with their film adaptations, so you get two things to argue about instead of one.
+- **[The Gloss Book Club](/book-clubs/#the-gloss-book-club)** is a global women's book club — everyone reads the same book worldwide, with local Vancouver meetups each month.
+
+## If you want free and reliable
+
+**[VPL Book Clubs](/book-clubs/#vpl-book-clubs)** — Vancouver Public Library runs free book clubs at branches across the city. They're welcoming, well-organized, and cost nothing. If you want something dependable and no-commitment, start here. (The library is also a goldmine for [starting your own group](/blog/start-a-group/) — the meeting rooms are free.)
+
+## How to actually stick with one
+
+The secret to book clubs — and to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/) generally — is repetition. The first meetup you'll feel like an outsider. By the third, you're a regular and someone's saved you a seat. Almost everyone quits after one visit, which is exactly why almost everyone stays lonely. Pick one, put the next three dates in your calendar, and just keep showing up.
+
+Not finding your niche? There are more clubs than any single guide can cover, and new ones join most weeks — [browse the full book clubs list](/book-clubs/), or [add one you know about](/submit/).
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/language-exchange-vancouver.md
+++ b/content/blog/language-exchange-vancouver.md
@@ -1,0 +1,45 @@
+---
+layout: post
+tags: post
+title: "Language exchange in Vancouver: where to practise (and meet people)"
+description: "Free language exchange meetups in Vancouver — Spanish, Mandarin, Japanese, French, Korean, and English conversation clubs, and how to get the most out of them."
+date: 2026-07-09
+faq:
+  - q: "Where can I do a language exchange in Vancouver?"
+    a: "Vancouver has regular language exchange meetups for Spanish, Mandarin, Japanese, French, Korean, and English conversation practice, most of them free and welcoming to beginners. The Vancouver Community Directory lists active ones on its language exchange page."
+  - q: "Are language exchange meetups in Vancouver free?"
+    a: "Most are. Groups like the Vancouver French Language Meetup and several English and Japanese conversation clubs are free to attend with no subscription — you just show up and practise."
+  - q: "Do I need to speak the language already?"
+    a: "No. Most language exchanges welcome all levels, including complete beginners. The format pairs learners with more fluent speakers of each language, so there's always someone to practise with at your level."
+  - q: "Are language exchanges a good way to make friends in Vancouver?"
+    a: "Yes — they're one of the most newcomer-friendly ways to meet people. The whole format is built around talking to strangers kindly, and because so much of Vancouver speaks a second language, the rooms are diverse and welcoming."
+---
+
+Language exchange might be the most underrated way to build a social life in Vancouver. The whole format is *designed* around talking to strangers — patiently, kindly, in two languages — which makes it one of the warmest, most newcomer-friendly rooms in the city. You come to practise a language; you leave with a standing Tuesday and a few new friends.
+
+Here's where to practise in Vancouver, by language, and how to get the most out of it. Every group below is a real, active meetup from [the directory's language exchange page](/language-exchange/).
+
+## By language
+
+- **Spanish & English** — **[Se Habla](/language-exchange/#se-habla-(english-%26-spanish))** runs language and cultural exchanges as part of a global network. One of the friendliest ways into the Spanish-speaking community here.
+- **Mandarin & English** — **[Vancouver Chinese/English Language Exchange](/language-exchange/#vancouver-chinese%2Fenglish-language-exchange)** is a casual practice-and-make-friends meetup for both languages.
+- **Japanese & English** — a few strong options: **[WASABI](/language-exchange/#wasabi-(japanese))** uses worksheets plus conversation, and **[YATTA! Canada](/language-exchange/#yatta!-canada-japanese-exchange)** runs friendly, regular Japanese language and culture meetups.
+- **French & English** — the **[Vancouver French Language Meetup](/language-exchange/#vancouver-french-language-meetup)** has been free since 2024, no subscription needed — just turn up and speak French.
+- **Korean & English** — **[Korean English Language Exchange](/language-exchange/#korean-english-language-exchange)** for Korean/English practice.
+- **English conversation** — for newcomers practising English, **[Make A Circle](/language-exchange/#make-a-circle---english-conversation-club)** prepares weekly topics, and **[Conversational English](/language-exchange/#conversational-english)** runs ESL conversation practice.
+
+## How to get the most out of a language exchange
+
+**Go alone, and go regularly.** Like every good social format in Vancouver, the value compounds — the second visit someone remembers you, the third you're a regular. (More on that in our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/).)
+
+**Trade fairly.** The unwritten rule of exchange is half your time in each language. Give as much patience as you'd like to receive when it's your turn to stumble.
+
+**It's fine to be a beginner.** Most groups welcome all levels — the whole point is that a fluent speaker of one language is a learner of another. Nobody's judging your accent; they're too busy worrying about theirs.
+
+If you'd rather meet people without the language angle, these rooms still count as some of the [best solo-friendly things to do in the city](/blog/things-to-do-alone-in-vancouver/) — you always have something to talk about.
+
+Looking for a specific language not listed? New groups join most weeks — [browse the full language exchange list](/language-exchange/), or [add one you know about](/submit/).
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/supper-clubs-dinner-with-strangers-vancouver.md
+++ b/content/blog/supper-clubs-dinner-with-strangers-vancouver.md
@@ -1,0 +1,50 @@
+---
+layout: post
+tags: post
+title: "Supper clubs and dinner with strangers in Vancouver"
+description: "Weekly dinners with strangers, underground supper clubs, and long-table pop-ups in Vancouver — how they work and how to find a seat at the table."
+date: 2026-07-09
+faq:
+  - q: "What is a dinner with strangers in Vancouver?"
+    a: "It's a dinner where you're seated with a small group of people you've never met — usually five or six — often at a surprise restaurant. Services like DayOfUs and Timeleft run these weekly in Vancouver, matching you with others based on interests. It's a low-pressure way to meet new people over a meal."
+  - q: "How do supper clubs work?"
+    a: "A supper club is a recurring or pop-up dining event — sometimes at a secret location, sometimes a long-table dinner or a themed pop-up. You buy a seat rather than a whole table, so you end up eating alongside people you don't know. Vancouver has both app-based dinners-with-strangers and underground pop-up supper clubs."
+  - q: "How do I meet people in Vancouver over dinner?"
+    a: "Book a seat at a dinner-with-strangers night (DayOfUs or Timeleft) or an underground supper club like Swallow Tail. Going alone is the norm and works better than bringing a friend — the whole point is that everyone at the table is there to meet someone new."
+  - q: "Is it weird to go to a supper club alone?"
+    a: "No — going solo is the standard way to attend a dinner-with-strangers night. Everyone else booked a single seat too, so you're all in the same boat. It's one of the least awkward ways to spend an evening meeting new people in Vancouver."
+---
+
+Somewhere between "grab a coffee sometime" and "come to my dinner party" sits the perfect Vancouver social format: a seat at a table full of strangers. You show up alone, you eat well, and by dessert you've met five people you'd never have crossed paths with otherwise. No hosting, no small-talk cold-start, no plus-one required.
+
+Here's how dinner-with-strangers and supper clubs work in Vancouver, and where to find a seat. Everything below is a real, active option from [the directory's dinner & supper clubs page](/dinner-supper-clubs/).
+
+## The weekly "dinner with strangers" services
+
+These are the easiest way in — book a seat, get matched, show up.
+
+- **[DayOfUs — Dinner with Strangers](/dinner-supper-clubs/#dayofus---dinner-with-strangers)** runs weekly curated dinners: you plus five strangers at a surprise restaurant, matched on your interests. It's casual, low-pressure, and the surprise-restaurant twist takes the decision fatigue out of it.
+- **[Timeleft](/dinner-supper-clubs/#timeleft)** is the international version, now running weekly in Vancouver. Same idea — algorithm-matched dinners with strangers — with a big enough network that there's almost always a table filling up.
+
+The magic of both: **going alone is the point.** A table of solo bookers bonds faster than a table where half the seats came in pairs. If you've been meaning to meet people but freeze at the "so who do I invite?" step, this format solves exactly that.
+
+## Underground supper clubs and pop-ups
+
+If you want the food to be the event, not just the backdrop:
+
+- **[Swallow Tail Pop-Up Dining](/dinner-supper-clubs/#swallow-tail-pop-up-dining)** runs underground dining events, secret supper clubs, and long-table dinners — creative, immersive nights for what they call "weird wonderful brains."
+- **[A Moveable Feast Supper Club](/dinner-supper-clubs/#a-moveable-feast-supper-club)** does French wine-bar-inspired dinners, pitched right in the sweet spot "between strangers and soon-to-be friends."
+
+These are more of an occasion — a great pick when you want a memorable night out that happens to be full of new people.
+
+## Why dinner works so well for meeting people
+
+Eating together is the oldest social technology there is. A shared table gives you a built-in reason to talk, a natural rhythm (courses!), and a fixed end time so there's no awkward "when do we leave?" A dinner with strangers is one of the highest-yield social hours in the city — which is why it's near the top of our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/) and our list of [things to do alone in Vancouver](/blog/things-to-do-alone-in-vancouver/).
+
+One tip: say yes to the after-plan. When someone at the table says "a few of us are getting a drink" — that's the actual invitation. Take it.
+
+Hungry for more? [Browse the full supper clubs list](/dinner-supper-clubs/), or if you run a pop-up or dinner series, [add it to the directory](/submit/).
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*


### PR DESCRIPTION
Grows the traffic that makes every sponsor slot worth more — three long-form guides on your highest-traffic proven themes, each funneling into its category page.

- **The best book clubs in Vancouver** → `/book-clubs/` (your #2 category)
- **Supper clubs and dinner with strangers in Vancouver** → `/dinner-supper-clubs/` (#3)
- **Language exchange in Vancouver** → `/language-exchange/`

Each has Article + FAQPage structured data, warm on-brand voice, and deep links to the actual real groups in that category. All 20 group deep links verified to resolve; guides auto-appear in the sitemap and blog index.

Chosen because the category pages already rank — these capture the "best / how / where" query variants the category page doesn't, and route that traffic straight into the listings (and their sponsor slots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_