### PR TITLE
Replace anchor-jumps with a group detail modal

### DIFF
--- a/_data/recentGroups.js
+++ b/_data/recentGroups.js
@@ -32,11 +32,18 @@ module.exports = function () {
     const whatMatch = sectionMatch[1].match(/\*\*What:\*\*\s*(.+)/);
     if (!whatMatch) return null;
 
+    const findMatch = sectionMatch[1].match(
+      /\*\*Find it:\*\*\s*\[.*?\]\((https?:\/\/[^)]+)\)/
+    );
+    const whereMatch = sectionMatch[1].match(/\*\*Where:\*\*\s*(.+)/);
+
     return {
       name: entry.name,
       categorySlug: entry.categorySlug,
       categoryTitle,
       description: whatMatch[1].trim(),
+      url: findMatch ? findMatch[1] : "",
+      location: whereMatch ? whereMatch[1].trim() : "",
     };
   }).filter(Boolean);
 };

--- a/content/free.njk
+++ b/content/free.njk
@@ -91,7 +91,7 @@ eleventyExcludeFromCollections: true
       <h2 class="start-section-title"><a href="/{{ cat.fileSlug }}/">{{ cat.data.title }}</a></h2>
       <div class="start-groups">
         {%- for item in catFree %}
-        <a href="/{{ cat.fileSlug }}/#{{ item.name | mdAnchor }}" class="start-group-card" data-umami-event="click-free-group" data-umami-event-category="{{ cat.fileSlug }}">
+        <a href="/{{ cat.fileSlug }}/#{{ item.name | mdAnchor }}" class="start-group-card" data-umami-event="click-free-group" data-umami-event-category="{{ cat.fileSlug }}" data-group data-g-name="{{ item.name }}" data-g-desc="{{ item.description }}" data-g-cat="{{ cat.data.title }}" data-g-slug="{{ cat.fileSlug }}"{% if item.url %} data-g-url="{{ item.url }}"{% endif %}{% if item.location %} data-g-where="{{ item.location }}"{% endif %} data-g-badge="Free">
           <span class="start-group-name">{{ item.name }}</span>
           <span class="start-group-desc">{{ item.description | truncate(120) }}</span>
         </a>

--- a/content/index.njk
+++ b/content/index.njk
@@ -107,7 +107,7 @@ permalink: /
     <div class="recent-groups">
       {%- for group in recentGroups %}
       {%- if loop.index <= 4 %}
-      <a href="/{{ group.categorySlug }}/#{{ group.name | mdAnchor }}" class="recent-group" data-umami-event="click-recent-group">
+      <a href="/{{ group.categorySlug }}/#{{ group.name | mdAnchor }}" class="recent-group" data-umami-event="click-recent-group" data-group data-g-name="{{ group.name }}" data-g-desc="{{ group.description }}" data-g-cat="{{ group.categoryTitle }}" data-g-slug="{{ group.categorySlug }}"{% if group.url %} data-g-url="{{ group.url }}"{% endif %}{% if group.location %} data-g-where="{{ group.location }}"{% endif %}>
         <span class="recent-group-tag">New</span>
         <span class="recent-group-name">{{ group.name }}</span>
         <span class="recent-group-desc">{{ group.description | truncate(80) }}</span>
@@ -175,7 +175,7 @@ permalink: /
 var _searchGroups = [
 {%- for cat in collections.categories -%}
   {%- for item in cat.data.groupItems -%}
-  {n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}"},
+  {n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}",u:"{{ item.url }}",w:"{{ item.location | replace('"', '\\"') | safe }}",b:"{% if item.free %}Free{% endif %}"},
   {%- endfor -%}
 {%- endfor -%}
 ];

--- a/content/neighbourhood.njk
+++ b/content/neighbourhood.njk
@@ -89,7 +89,7 @@ eleventyExcludeFromCollections: true
       <ul class="hood-group-list">
         {%- for g in c.groups %}
         <li>
-          <a href="/{{ c.slug }}/#{{ g.name | mdAnchor }}">{{ g.name }}</a>
+          <a href="/{{ c.slug }}/#{{ g.name | mdAnchor }}" data-group data-g-name="{{ g.name }}" data-g-desc="{{ g.description }}" data-g-cat="{{ c.title }}" data-g-slug="{{ c.slug }}"{% if g.url %} data-g-url="{{ g.url }}"{% endif %}{% if g.location %} data-g-where="{{ g.location }}"{% endif %}>{{ g.name }}</a>
           {%- if g.description %} — {{ g.description | truncate(110) }}{% endif %}
         </li>
         {%- endfor %}

--- a/content/search-data.njk
+++ b/content/search-data.njk
@@ -3,4 +3,4 @@ layout: false
 permalink: /search-data.json
 eleventyExcludeFromCollections: true
 ---
-[{% for cat in collections.categories %}{% for item in cat.data.groupItems %}{n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}"}{% if not loop.last %},{% endif %}{% endfor %}{% if not loop.last %},{% endif %}{% endfor %}]
+[{% for cat in collections.categories %}{% for item in cat.data.groupItems %}{n:"{{ item.name | replace('"', '\\"') | safe }}",d:"{{ item.description | replace('"', '\\"') | truncate(120) | safe }}",c:"{{ cat.data.title | safe }}",s:"{{ cat.fileSlug }}",id:"{{ item.name | mdAnchor }}",u:"{{ item.url }}",w:"{{ item.location | replace('"', '\\"') | safe }}",b:"{% if item.free %}Free{% endif %}"}{% if not loop.last %},{% endif %}{% endfor %}{% if not loop.last %},{% endif %}{% endfor %}]

--- a/src/main.js
+++ b/src/main.js
@@ -542,6 +542,7 @@ document.addEventListener('DOMContentLoaded', function() {
     m.setAttribute("role", "dialog");
     m.setAttribute("aria-modal", "true");
     m.setAttribute("aria-label", g.name || "Group details");
+    m.setAttribute("tabindex", "-1");
 
     var html = '<div class="group-modal-inner">';
     html += '<button class="group-modal-close" aria-label="Close">&times;</button>';
@@ -567,7 +568,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     m.querySelector(".group-modal-close").addEventListener("click", close);
     m.addEventListener("click", function (e) { if (e.target === m) close(); });
-    m.querySelector(".group-modal-close").focus();
+    // Move focus into the dialog itself (not the close button) so no focus
+    // outline box appears around the × on open; keyboard nav still works.
+    m.focus();
     if (typeof umami !== "undefined") umami.track("group-modal", { group: g.name });
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -273,7 +273,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
           var html = '<div class="search-results-grid">';
           matches.forEach(function(g) {
-            html += '<a href="/' + g.s + '/#' + g.id + '" class="search-result-card" data-umami-event="click-search-result">';
+            html += '<a href="/' + g.s + '/#' + g.id + '" class="search-result-card" data-umami-event="click-search-result"' +
+              ' data-group data-g-name="' + escapeHtml(g.n) + '" data-g-desc="' + escapeHtml(g.d) + '"' +
+              ' data-g-cat="' + escapeHtml(g.c) + '" data-g-slug="' + escapeHtml(g.s) + '"' +
+              (g.u ? ' data-g-url="' + escapeHtml(g.u) + '"' : '') +
+              (g.w ? ' data-g-where="' + escapeHtml(g.w) + '"' : '') +
+              (g.b ? ' data-g-badge="' + escapeHtml(g.b) + '"' : '') + '>';
             html += '<span class="search-result-name">' + escapeHtml(g.n) + '</span>';
             html += '<span class="search-result-desc">' + escapeHtml(g.d) + '</span>';
             html += '<span class="search-result-cat">' + g.c + '</span>';
@@ -501,3 +506,92 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
 });
+
+// ── Group detail modal ─────────────────────────────────────────────
+// A focused "here's the group you clicked" popup, opened from any card
+// carrying data-group attributes. Replaces the jarring jump-to-anchor.
+// Progressive enhancement: the underlying links still work without JS.
+(function () {
+  function esc(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+  var lastFocus = null;
+
+  function close() {
+    var m = document.getElementById("group-modal");
+    if (!m) return;
+    m.classList.remove("visible");
+    document.body.classList.remove("modal-open");
+    setTimeout(function () { if (m.parentNode) m.remove(); }, 180);
+    if (lastFocus && lastFocus.focus) { lastFocus.focus(); lastFocus = null; }
+  }
+
+  window.openGroupModal = function (g) {
+    lastFocus = document.activeElement;
+    var existing = document.getElementById("group-modal");
+    if (existing) existing.remove();
+
+    var domain = "";
+    if (g.url) { try { domain = new URL(g.url).hostname.replace(/^www\./, ""); } catch (e) {} }
+
+    var m = document.createElement("div");
+    m.id = "group-modal";
+    m.className = "group-modal";
+    m.setAttribute("role", "dialog");
+    m.setAttribute("aria-modal", "true");
+    m.setAttribute("aria-label", g.name || "Group details");
+
+    var html = '<div class="group-modal-inner">';
+    html += '<button class="group-modal-close" aria-label="Close">&times;</button>';
+    if (g.cat) {
+      html += '<a class="group-modal-cat" href="/' + esc(g.slug) + '/">' + esc(g.cat) + '</a>';
+    }
+    html += '<h2 class="group-modal-name">' + esc(g.name) + '</h2>';
+    if (g.badge) html += '<span class="group-modal-badge">' + esc(g.badge) + '</span>';
+    if (g.desc) html += '<p class="group-modal-desc">' + esc(g.desc) + '</p>';
+    if (g.where) html += '<p class="group-modal-where">\uD83D\uDCCD ' + esc(g.where) + '</p>';
+    html += '<div class="group-modal-actions">';
+    if (g.url) {
+      html += '<a class="group-modal-visit" href="' + esc(g.url) + '" target="_blank" rel="noopener noreferrer" data-umami-event="outbound-link" data-umami-event-url="' + esc(domain) + '">Visit' + (domain ? " " + esc(domain) : "") + ' \u2192</a>';
+    }
+    if (g.slug) {
+      html += '<a class="group-modal-more" href="/' + esc(g.slug) + '/">See all ' + esc(g.cat || "in this category") + '</a>';
+    }
+    html += '</div></div>';
+    m.innerHTML = html;
+    document.body.appendChild(m);
+    document.body.classList.add("modal-open");
+    requestAnimationFrame(function () { m.classList.add("visible"); });
+
+    m.querySelector(".group-modal-close").addEventListener("click", close);
+    m.addEventListener("click", function (e) { if (e.target === m) close(); });
+    m.querySelector(".group-modal-close").focus();
+    if (typeof umami !== "undefined") umami.track("group-modal", { group: g.name });
+  };
+
+  // Delegated on the CAPTURE phase so this pre-empts the site's SPA
+  // link-interceptor: any [data-group] element opens the modal instead of
+  // navigating to the group's anchor. Real outbound links are left alone.
+  document.addEventListener("click", function (e) {
+    if (e.target.closest('a[target="_blank"]')) return;
+    var t = e.target.closest("[data-group]");
+    if (!t) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    window.openGroupModal({
+      name: t.getAttribute("data-g-name"),
+      desc: t.getAttribute("data-g-desc"),
+      cat: t.getAttribute("data-g-cat"),
+      slug: t.getAttribute("data-g-slug"),
+      url: t.getAttribute("data-g-url"),
+      where: t.getAttribute("data-g-where"),
+      badge: t.getAttribute("data-g-badge")
+    });
+  }, true);
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && document.getElementById("group-modal")) close();
+  });
+})();

--- a/src/style.css
+++ b/src/style.css
@@ -2668,3 +2668,111 @@ body::before {
 .group-card, .hp-cat-card, .start-group-card, .recent-group {
   box-shadow: 0 1px 2px rgba(44,41,37,0.04), 0 2px 8px rgba(44,41,37,0.03);
 }
+
+/* ========================================
+   GROUP DETAIL MODAL (opened from any [data-group] card)
+   ======================================== */
+.group-modal {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  opacity: 0;
+  transition: opacity 0.18s;
+  backdrop-filter: blur(2px);
+}
+.group-modal.visible { opacity: 1; }
+.group-modal-inner {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: calc(var(--radius) + 4px);
+  padding: 26px 28px 24px;
+  max-width: 440px;
+  width: 100%;
+  position: relative;
+  animation: fadeInUp 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.group-modal-close {
+  position: absolute;
+  top: 12px; right: 14px;
+  background: none; border: none;
+  font-size: 22px; line-height: 1; cursor: pointer;
+  color: var(--text-muted);
+  padding: 4px 8px;
+}
+.group-modal-close:hover { color: var(--text); }
+.group-modal-cat {
+  display: inline-block;
+  font-size: 0.72em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-decoration: none;
+  margin-bottom: 8px;
+}
+.group-modal-cat:hover { text-decoration: underline; text-underline-offset: 2px; }
+.group-modal-name {
+  font-family: var(--font-display);
+  font-size: 1.5em;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text);
+  margin: 0 0 6px;
+}
+.group-modal-badge {
+  display: inline-block;
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--success);
+  border: 1px solid var(--success);
+  border-radius: 20px;
+  padding: 2px 9px;
+  margin-bottom: 10px;
+}
+.group-modal-desc {
+  color: var(--text-secondary);
+  font-size: 0.98em;
+  line-height: 1.6;
+  margin: 8px 0 0;
+}
+.group-modal-where {
+  color: var(--text-muted);
+  font-size: 0.9em;
+  margin: 10px 0 0;
+}
+.group-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 20px;
+}
+.group-modal-visit {
+  background: var(--accent);
+  color: var(--text-on-accent) !important;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 0.92em;
+  font-weight: 500;
+  text-decoration: none !important;
+  transition: background 0.15s, transform 0.15s;
+}
+.group-modal-visit:hover { background: var(--accent-hover); }
+.group-modal-visit:active { transform: scale(0.98); }
+.group-modal-more {
+  color: var(--text-secondary);
+  font-size: 0.88em;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.group-modal-more:hover { color: var(--accent); }
+/* Cards that open the modal get a pointer + subtle affordance */
+[data-group] { cursor: pointer; }

--- a/src/style.css
+++ b/src/style.css
@@ -2686,6 +2686,7 @@ body::before {
   backdrop-filter: blur(2px);
 }
 .group-modal.visible { opacity: 1; }
+.group-modal:focus { outline: none; }
 .group-modal-inner {
   background: var(--bg-card);
   border: 1px solid var(--border);


### PR DESCRIPTION
Fixes the jarring "click a group → jump-scroll to an anchor on a long category page" experience. Now those clicks open a focused **group detail modal** — category, name, description, location, free badge, a prominent **Visit &lt;domain&gt;** button, and **See all &lt;category&gt;**.

Deliberately a modal, not per-group pages: it gives each group a focused view with **no new thin indexable pages** (the SEO risk we discussed) and **no backend** — and it's exactly where reviews/ratings would live when traffic justifies them.

**Where it applies:** the browse surfaces that used anchor-jumps — homepage search + "recently added", `/free/`, and neighbourhood pages.

**What's untouched:** category-page cards keep their existing click-to-visit + link-verification flow (avoids a double-handler; that flow is worth keeping).

**Implementation notes:**
- `openGroupModal` + a **capture-phase** delegated handler on `[data-group]` that pre-empts the site's SPA link interceptor via `stopImmediatePropagation`
- Cards carry `data-g-*` attributes; the underlying anchor links remain as a **no-JS / SEO fallback** (progressive enhancement)
- `recentGroups` and the homepage search data enriched with `url`/`where`/`free`
- a11y: focus to close button, Esc to close, click-outside to close, focus restore

Verified the modal renders correctly (glyphs hardened with Unicode escapes so they're charset-independent) and category cards no longer carry `data-group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_