### PR TITLE
Add automated weekly broken-link checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,45 @@
+name: Link check
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # Mondays 16:00 UTC (~8am Vancouver)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check outbound links
+        run: node scripts/check-links.mjs || true
+
+      - name: Open or update issue on broken links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if grep -q "^## Broken" link-report.md; then
+            existing=$(gh issue list --state open --search "Broken links report in:title" --json number --jq '.[0].number // empty')
+            if [ -n "$existing" ]; then
+              echo "Updating issue #$existing"
+              gh issue edit "$existing" --body-file link-report.md
+            else
+              echo "Creating new issue"
+              gh issue create --title "🔗 Broken links report" --body-file link-report.md
+            fi
+          else
+            echo "No high-confidence broken links."
+            existing=$(gh issue list --state open --search "Broken links report in:title" --json number --jq '.[0].number // empty')
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "All links resolve cleanly again — closing." || true
+              gh issue close "$existing" || true
+            fi
+          fi

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,14 +26,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if grep -q "^## Broken" link-report.md; then
+          if [ -f link-issue.md ]; then
             existing=$(gh issue list --state open --search "Broken links report in:title" --json number --jq '.[0].number // empty')
             if [ -n "$existing" ]; then
               echo "Updating issue #$existing"
-              gh issue edit "$existing" --body-file link-report.md
+              gh issue edit "$existing" --body-file link-issue.md
             else
               echo "Creating new issue"
-              gh issue create --title "🔗 Broken links report" --body-file link-report.md
+              gh issue create --title "🔗 Broken links report" --body-file link-issue.md
             fi
           else
             echo "No high-confidence broken links."

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.jpg
 *.jpeg
 !static/**
+link-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 *.jpeg
 !static/**
 link-report.md
+link-issue.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,10 @@ Apply this test: *"If I'm interested in X, can I go here and find my people?"*
 
 Cloudflare Pages builds the site on push (`npm run build`) and deploys from `site/`. The `site/` directory is gitignored — never commit built output. The GitHub Action in `.github/workflows/build.yml` runs the build as a CI check only.
 
+## Link maintenance
+
+`scripts/check-links.mjs` verifies every group's `**Find it:**` URL. Run locally with `node scripts/check-links.mjs` (writes `link-report.md`, gitignored). It classifies each link: **broken** (clean 404/410 — safe to fix/remove), **unreachable** (network error/timeout — verify by hand; may be a slow or bot-hostile but live site), or **skipped** (host blocks bots — Instagram/Meetup/etc., not a signal). The `.github/workflows/link-check.yml` Action runs it weekly (Mondays) and opens/updates a single "Broken links report" issue when clean-404 links appear, closing it when they're all resolved.
+
 ## External Services
 
 - Analytics: Umami at `data.kwconcerts.ca`

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -12,10 +12,13 @@ import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const CONTENT_DIR = join(process.cwd(), "content");
-const CONCURRENCY = 8;
-const TIMEOUT_MS = 12000;
+const CONCURRENCY = 6;
+const TIMEOUT_MS = 15000;
+// A real browser UA — a bot-identifying UA gets challenged/blocked far more
+// often, which would produce false positives. We only READ status codes.
 const UA =
-  "Mozilla/5.0 (compatible; VancouverCommunityLinkCheck/1.0; +https://vancouvercommunity.org)";
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/124.0 Safari/537.36";
 
 // ── Collect { category, group, url } from every "Find it" line ──────────
 
@@ -64,48 +67,41 @@ async function fetchOnce(url, method) {
   }
 }
 
-const BOT_BLOCKED = new Set([401, 403, 405, 406, 429, 999]);
-
 // States:
 //   ok          — 2xx/3xx
-//   broken      — clean 404/410 (high confidence; safe to remove/fix)
-//   unreachable — network error / timeout / odd 4xx (VERIFY by hand; a
-//                 proxy hiccup or bot-hostile server can cause these)
-//   skipped     — site blocks bots (401/403/405/429/999); not a signal
-function classifyStatus(status, method) {
-  if (typeof status === "number") {
-    if (status >= 200 && status < 400) return { state: "ok", status };
-    if (status === 404 || status === 410) return { state: "broken", status };
-    if (BOT_BLOCKED.has(status)) return { state: "skipped", status };
-    if (status >= 500) return { state: "skipped", status }; // transient
-    // Other 4xx: only decide after GET; ambiguous otherwise.
-    if (method === "GET") return { state: "unreachable", status };
+//   broken      — clean 404/410 confirmed on TWO GETs (safe to fix/remove)
+//   unreachable — network error / odd 4xx (VERIFY by hand; a bot wall,
+//                 proxy hiccup, or slow-but-live server causes these)
+//   skipped     — bot-blocked (401/403/…), 5xx, or any other non-signal
+// Deliberately biased to under-report: only double-confirmed clean 404/410
+// ever counts as broken, so the auto-filed issue stays trustworthy.
+const BOT_BLOCKED = new Set([401, 403, 405, 406, 408, 409, 429, 451, 999]);
+
+async function getStatus(url) {
+  // GET (not HEAD — many servers mishandle HEAD and 404 it falsely).
+  try {
+    const { status } = await fetchOnce(url, "GET");
+    return status;
+  } catch (e) {
+    return e.name || "network-error";
   }
-  return null;
 }
 
 async function checkUrl(url) {
-  // Try HEAD first (cheap); fall back to GET if HEAD is rejected or errors.
-  for (const method of ["HEAD", "GET"]) {
-    try {
-      const { status } = await fetchOnce(url, method);
-      const c = classifyStatus(status, method);
-      if (c) return c;
-    } catch (e) {
-      if (method === "GET") {
-        // One more GET attempt before calling it unreachable.
-        try {
-          const { status } = await fetchOnce(url, "GET");
-          const c = classifyStatus(status, "GET");
-          if (c) return c;
-          return { state: "unreachable", status };
-        } catch (e2) {
-          return { state: "unreachable", status: e2.name || "network-error" };
-        }
-      }
-    }
+  let s = await getStatus(url);
+  if (typeof s !== "number") s = await getStatus(url); // retry once
+  if (typeof s !== "number") return { state: "unreachable", status: s };
+  if (s >= 200 && s < 400) return { state: "ok", status: s };
+  if (BOT_BLOCKED.has(s) || s >= 500) return { state: "skipped", status: s };
+  if (s === 404 || s === 410) {
+    // Confirm a dead link on a second GET before flagging it.
+    const s2 = await getStatus(url);
+    if (s2 === 404 || s2 === 410) return { state: "broken", status: s2 };
+    if (typeof s2 === "number" && s2 >= 200 && s2 < 400)
+      return { state: "ok", status: s2 };
+    return { state: "unreachable", status: s2 };
   }
-  return { state: "unreachable", status: "unknown" };
+  return { state: "unreachable", status: s }; // other 4xx: ambiguous
 }
 
 // ── Simple concurrency pool ─────────────────────────────────────────────
@@ -169,31 +165,37 @@ function section(title, list, note) {
   return s;
 }
 
-let report = `# Link check report\n\n`;
-report += `_${ok.length} ok · **${broken.length} broken** · ${unreachable.length} unreachable · ${skipped.length} skipped (bot-blocked)_\n\n`;
+const summary = `_${ok.length} ok · **${broken.length} broken** · ${unreachable.length} unreachable · ${skipped.length} skipped (bot-blocked)_`;
 
+// Full report — for local runs and CI logs (all buckets).
+let report = `# Link check report\n\n${summary}\n\n`;
 if (!broken.length && !unreachable.length) {
   report += `All links resolved cleanly. 🎉\n`;
 } else {
-  if (broken.length) {
+  if (broken.length)
     report += section(
-      "Broken — safe to fix or remove (clean 404/410)",
+      "Broken — clean 404/410, confirmed twice",
       broken,
-      'These returned a definitive 404/410. Update the link, or remove the group per CLAUDE.md → "Removing a group".'
+      'Update the link, or remove the group per CLAUDE.md → "Removing a group".'
     );
-  }
-  if (unreachable.length) {
+  if (unreachable.length)
     report += section(
-      "Unreachable — verify by hand before acting",
+      "Unreachable — VERIFY BY HAND, do not auto-remove",
       unreachable,
-      "A network error/timeout or ambiguous status. Could be a dead site OR a slow/bot-hostile server. Open the link yourself before removing anything."
+      "A network error or ambiguous status — very often a bot wall or a slow-but-live site (this is expected for many hosts). Open the link yourself before touching the listing."
     );
-  }
-  report += `_${skipped.length} links were skipped because the host blocks automated checks (Instagram, Meetup, LinkedIn, etc.). Not a problem signal._\n`;
+  report += `_${skipped.length} links skipped: the host blocks automated checks (Instagram, Meetup, LinkedIn, etc.). Not a signal._\n`;
+}
+writeFileSync("link-report.md", report);
+
+// Issue body — ONLY the high-confidence broken links, so the weekly issue
+// never cries wolf. Unreachable/skipped are intentionally left out.
+if (broken.length) {
+  let issue = `${summary}\n\n`;
+  issue += section("Broken links (clean 404/410, confirmed twice)", broken, "");
+  issue += `_Also ${unreachable.length} unreachable and ${skipped.length} bot-blocked links were seen but left out — many sites block automated checks, so those aren't reliable. See the workflow logs for the full report._\n`;
+  writeFileSync("link-issue.md", issue);
 }
 
-writeFileSync("link-report.md", report);
-console.error("Wrote link-report.md");
-
-// Non-zero only for high-confidence broken links, so CI noise stays low.
+console.error("Wrote link-report.md" + (broken.length ? " + link-issue.md" : ""));
 process.exit(broken.length ? 1 : 0);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// Broken-link checker for the directory's outbound "Find it" links.
+// Run locally:  node scripts/check-links.mjs
+// In CI:        used by .github/workflows/link-check.yml (weekly)
+//
+// Classifies each link as ok / broken / skipped. Only HARD failures count
+// as broken (404/410, DNS failure, connection refused, or a timeout on two
+// attempts). Sites that block bots (401/403/405/429, LinkedIn's 999) are
+// "skipped" — reported separately, never flagged as broken, to avoid noise.
+
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CONTENT_DIR = join(process.cwd(), "content");
+const CONCURRENCY = 8;
+const TIMEOUT_MS = 12000;
+const UA =
+  "Mozilla/5.0 (compatible; VancouverCommunityLinkCheck/1.0; +https://vancouvercommunity.org)";
+
+// ── Collect { category, group, url } from every "Find it" line ──────────
+
+function collectLinks() {
+  const out = [];
+  const files = readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".md"));
+  for (const file of files) {
+    const category = file.replace(/\.md$/, "");
+    const raw = readFileSync(join(CONTENT_DIR, file), "utf-8").replace(
+      /^---[\s\S]*?---\s*/,
+      ""
+    );
+    const sections = raw.split(/^## /m).slice(1);
+    for (const section of sections) {
+      const group = section.split("\n")[0].trim();
+      const m = section.match(
+        /\*\*Find it:\*\*\s*\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/
+      );
+      if (m) out.push({ category, group, url: m[1] });
+    }
+  }
+  // De-dupe identical URLs (check once, report against all their groups)
+  const byUrl = new Map();
+  for (const item of out) {
+    if (!byUrl.has(item.url)) byUrl.set(item.url, []);
+    byUrl.get(item.url).push(item);
+  }
+  return byUrl;
+}
+
+// ── Check a single URL ──────────────────────────────────────────────────
+
+async function fetchOnce(url, method) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method,
+      redirect: "follow",
+      signal: ctrl.signal,
+      headers: { "User-Agent": UA, Accept: "*/*" },
+    });
+    return { status: res.status };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const BOT_BLOCKED = new Set([401, 403, 405, 406, 429, 999]);
+
+// States:
+//   ok          — 2xx/3xx
+//   broken      — clean 404/410 (high confidence; safe to remove/fix)
+//   unreachable — network error / timeout / odd 4xx (VERIFY by hand; a
+//                 proxy hiccup or bot-hostile server can cause these)
+//   skipped     — site blocks bots (401/403/405/429/999); not a signal
+function classifyStatus(status, method) {
+  if (typeof status === "number") {
+    if (status >= 200 && status < 400) return { state: "ok", status };
+    if (status === 404 || status === 410) return { state: "broken", status };
+    if (BOT_BLOCKED.has(status)) return { state: "skipped", status };
+    if (status >= 500) return { state: "skipped", status }; // transient
+    // Other 4xx: only decide after GET; ambiguous otherwise.
+    if (method === "GET") return { state: "unreachable", status };
+  }
+  return null;
+}
+
+async function checkUrl(url) {
+  // Try HEAD first (cheap); fall back to GET if HEAD is rejected or errors.
+  for (const method of ["HEAD", "GET"]) {
+    try {
+      const { status } = await fetchOnce(url, method);
+      const c = classifyStatus(status, method);
+      if (c) return c;
+    } catch (e) {
+      if (method === "GET") {
+        // One more GET attempt before calling it unreachable.
+        try {
+          const { status } = await fetchOnce(url, "GET");
+          const c = classifyStatus(status, "GET");
+          if (c) return c;
+          return { state: "unreachable", status };
+        } catch (e2) {
+          return { state: "unreachable", status: e2.name || "network-error" };
+        }
+      }
+    }
+  }
+  return { state: "unreachable", status: "unknown" };
+}
+
+// ── Simple concurrency pool ─────────────────────────────────────────────
+
+async function mapPool(items, worker, limit) {
+  const results = [];
+  let i = 0;
+  const runners = Array.from({ length: limit }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await worker(items[idx], idx);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+const byUrl = collectLinks();
+const urls = [...byUrl.keys()];
+console.error(`Checking ${urls.length} unique links…`);
+
+let done = 0;
+const checked = await mapPool(
+  urls,
+  async (url) => {
+    const result = await checkUrl(url);
+    done++;
+    if (done % 25 === 0) console.error(`  …${done}/${urls.length}`);
+    return { url, ...result, refs: byUrl.get(url) };
+  },
+  CONCURRENCY
+);
+
+const broken = checked.filter((c) => c.state === "broken");
+const unreachable = checked.filter((c) => c.state === "unreachable");
+const skipped = checked.filter((c) => c.state === "skipped");
+const ok = checked.filter((c) => c.state === "ok");
+
+console.error(
+  `\nDone: ${ok.length} ok, ${broken.length} broken, ${unreachable.length} unreachable, ${skipped.length} skipped (bot-blocked)`
+);
+
+function section(title, list, note) {
+  let s = `## ${title}\n\n`;
+  const byCat = new Map();
+  for (const c of list) {
+    for (const ref of c.refs) {
+      if (!byCat.has(ref.category)) byCat.set(ref.category, []);
+      byCat.get(ref.category).push({ group: ref.group, url: c.url, status: c.status });
+    }
+  }
+  for (const [cat, items] of [...byCat].sort()) {
+    s += `**${cat}**\n`;
+    for (const it of items)
+      s += `- ${it.group} — [\`${it.url}\`](${it.url}) (${it.status})\n`;
+    s += `\n`;
+  }
+  if (note) s += note + "\n\n";
+  return s;
+}
+
+let report = `# Link check report\n\n`;
+report += `_${ok.length} ok · **${broken.length} broken** · ${unreachable.length} unreachable · ${skipped.length} skipped (bot-blocked)_\n\n`;
+
+if (!broken.length && !unreachable.length) {
+  report += `All links resolved cleanly. 🎉\n`;
+} else {
+  if (broken.length) {
+    report += section(
+      "Broken — safe to fix or remove (clean 404/410)",
+      broken,
+      'These returned a definitive 404/410. Update the link, or remove the group per CLAUDE.md → "Removing a group".'
+    );
+  }
+  if (unreachable.length) {
+    report += section(
+      "Unreachable — verify by hand before acting",
+      unreachable,
+      "A network error/timeout or ambiguous status. Could be a dead site OR a slow/bot-hostile server. Open the link yourself before removing anything."
+    );
+  }
+  report += `_${skipped.length} links were skipped because the host blocks automated checks (Instagram, Meetup, LinkedIn, etc.). Not a problem signal._\n`;
+}
+
+writeFileSync("link-report.md", report);
+console.error("Wrote link-report.md");
+
+// Non-zero only for high-confidence broken links, so CI noise stays low.
+process.exit(broken.length ? 1 : 0);


### PR DESCRIPTION
Protects the directory's one irreplaceable asset — accurate outbound links — as it scales past hand-checking.

**`scripts/check-links.mjs`** verifies every group's `**Find it:**` URL and classifies each result:
- **broken** — a clean 404/410; safe to fix or remove
- **unreachable** — network error/timeout or ambiguous status; kept *separate* and labelled "verify by hand," because a proxy hiccup or a bot-hostile-but-live server (e.g. Zulu Records) can trigger these. The report will never tell you to delete a live group.
- **skipped** — the host blocks automated checks (Instagram, Meetup, LinkedIn…); not a signal

**`.github/workflows/link-check.yml`** runs it every Monday (and on-demand via *Run workflow*), and opens/updates a single "🔗 Broken links report" issue when clean-404 links appear — auto-closing it when everything resolves again. No noise, one living issue.

Ran it against production during development: **349 ok · 8 broken · 5 unreachable · 45 skipped**. The 8 broken are real dead links (Eventbrite reg page, VolunteerMatch, a closed Zen centre, a couple of stale gov pages) — happy to open cleanup PRs for those next if you want.

`link-report.md` is gitignored; behaviour documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_