### PR TITLE
Link health: harden checker vs bot-hostile 404s + fix 4 dead links

### DIFF
--- a/content/dinner-supper-clubs.md
+++ b/content/dinner-supper-clubs.md
@@ -12,7 +12,7 @@ order: 1
 
 ## DayOfUs - Dinner with Strangers
 - **What:** Weekly curated dinners — you + 5 strangers at a surprise restaurant. Algorithm-matched based on interests, casual, low-pressure
-- **Find it:** [Eventbrite](https://www.eventbrite.com/e/dinner-with-strangers-curated-dinner-meetup-in-vancouver-registration-1709285481889)
+- **Find it:** [dayofus.com/events/vancouver](https://www.dayofus.com/events/vancouver)
 
 ## Timeleft
 - **What:** International app, weekly dinners with strangers. Algorithm-matched, launched in Vancouver May 2024

--- a/content/foraging-nature.md
+++ b/content/foraging-nature.md
@@ -29,7 +29,7 @@ order: 3
 
 ## A Taste of Nature
 - **What:** Daily eco-tours through Stanley Park, "Forest to Table Cuisine"
-- **Find it:** [destinationvancouver.com/listings/a-taste-of-nature](https://www.destinationvancouver.com/listings/a-taste-of-nature/56116/)
+- **Find it:** [atasteofnature.ca](https://www.atasteofnature.ca)
 
 ## Deerholme Farm Forages
 - **What:** Wild food forages for mushrooms and plants. Educational, hands-on, Vancouver Island day trips

--- a/content/resources.md
+++ b/content/resources.md
@@ -92,10 +92,6 @@ order: 3
 - **What:** Cycling clubs and resources in BC
 - **Find it:** [bikehub.ca](https://bikehub.ca)
 
-## HoopMaps
-- **What:** App for finding pickup basketball games
-- **Find it:** [App Store](https://apps.apple.com/app/hoop-maps-find-pickup-basketball-games/id1144928566)
-
 ## ClimbFind
 - **What:** Find climbing partners and groups
 - **Find it:** [climbfind.com](https://climbfind.com)

--- a/content/tech-startup.md
+++ b/content/tech-startup.md
@@ -2,7 +2,7 @@
 layout: category
 tags: category
 title: "Tech & Startup"
-description: "39 tech and startup groups — founder circles, dev meetups, AI nights, cybersecurity, and more. Vancouver's largest category."
+description: "40 tech and startup groups — founder circles, dev meetups, AI nights, cybersecurity, and more. Vancouver's largest category."
 emoji: "💼"
 group: work-tech
 order: 1
@@ -78,10 +78,6 @@ order: 1
 ## Cloud Native Vancouver
 - **What:** Official CNCF chapter for Kubernetes, containers, cloud-native tech. Technical deep-dives, passionate community
 - **Find it:** [lu.ma/cloudnativevan](https://lu.ma/cloudnativevan)
-
-## Vancouver Cloud Events
-- **What:** AWS, Azure, and GCP events aggregated in one place. Cloud Summit, meetups across all major cloud platforms
-- **Find it:** [lu.ma/VancouverCloud](https://lu.ma/VancouverCloud)
 
 ## Novus
 - **What:** Community of founders and builders working on impactful projects. High-caliber, impact-focused, scale-minded

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -19,6 +19,10 @@ const TIMEOUT_MS = 15000;
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
   "(KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+// A deliberately DIFFERENT signature, used only to double-check a 404 before
+// flagging it. Bot-hostile sites (e.g. some .gov pages) hand back different
+// codes to different clients — if the two disagree, the "404" isn't reliable.
+const UA_ALT = "curl/8.4.0";
 
 // ── Collect { category, group, url } from every "Find it" line ──────────
 
@@ -51,7 +55,7 @@ function collectLinks() {
 
 // ── Check a single URL ──────────────────────────────────────────────────
 
-async function fetchOnce(url, method) {
+async function fetchOnce(url, method, ua = UA) {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
@@ -59,7 +63,7 @@ async function fetchOnce(url, method) {
       method,
       redirect: "follow",
       signal: ctrl.signal,
-      headers: { "User-Agent": UA, Accept: "*/*" },
+      headers: { "User-Agent": ua, Accept: "*/*" },
     });
     return { status: res.status };
   } finally {
@@ -77,10 +81,10 @@ async function fetchOnce(url, method) {
 // ever counts as broken, so the auto-filed issue stays trustworthy.
 const BOT_BLOCKED = new Set([401, 403, 405, 406, 408, 409, 429, 451, 999]);
 
-async function getStatus(url) {
+async function getStatus(url, ua = UA) {
   // GET (not HEAD — many servers mishandle HEAD and 404 it falsely).
   try {
-    const { status } = await fetchOnce(url, "GET");
+    const { status } = await fetchOnce(url, "GET", ua);
     return status;
   } catch (e) {
     return e.name || "network-error";
@@ -94,12 +98,14 @@ async function checkUrl(url) {
   if (s >= 200 && s < 400) return { state: "ok", status: s };
   if (BOT_BLOCKED.has(s) || s >= 500) return { state: "skipped", status: s };
   if (s === 404 || s === 410) {
-    // Confirm a dead link on a second GET before flagging it.
-    const s2 = await getStatus(url);
+    // Re-check with a DIFFERENT client signature. Bot-hostile hosts (some
+    // .gov pages) return 404 to one client and 403 to another — if the two
+    // disagree, the "404" isn't trustworthy, so downgrade to verify-by-hand.
+    const s2 = await getStatus(url, UA_ALT);
     if (s2 === 404 || s2 === 410) return { state: "broken", status: s2 };
     if (typeof s2 === "number" && s2 >= 200 && s2 < 400)
       return { state: "ok", status: s2 };
-    return { state: "unreachable", status: s2 };
+    return { state: "unreachable", status: `404→${s2}` };
   }
   return { state: "unreachable", status: s }; // other 4xx: ambiguous
 }


### PR DESCRIPTION
Two things, both from the link-checker's first real run.

**Checker hardening (your "sites block you weirdly" point, proven true):** before flagging a 404/410, it now re-checks with a *different* client signature (a curl UA). Bot-hostile hosts — notably some `.gov` pages — hand back 404 to one client and 403 to another; when they disagree, the link is downgraded to "verify by hand" instead of "broken." On the first run this exact case produced 2 false positives (`vancouver.ca`, `westvancouver.ca`) — both now correctly excluded.

**The 4 genuinely-dead links, each verified by hand + web search:**
- **Update** DayOfUs → `dayofus.com/events/vancouver` (moved off an expired Eventbrite reg link; service is very much alive)
- **Update** A Taste of Nature → `atasteofnature.ca` (the Destination Vancouver listing was delisted; the Stanley Park tour still runs)
- **Remove** HoopMaps — the Shark Tank company is out of business, app delisted
- **Remove** Vancouver Cloud Events — dead lu.ma calendar with no faithful replacement
- Corrected a stale hardcoded count in the tech-startup description (39 → 40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_