### PR TITLE
Add 3 more SEO guides: hiking, cycling, creative/art

### DIFF
--- a/content/blog/creative-and-art-groups-in-vancouver.md
+++ b/content/blog/creative-and-art-groups-in-vancouver.md
@@ -1,0 +1,53 @@
+---
+layout: post
+tags: post
+title: "Creative and art groups in Vancouver (draw, sketch, make friends)"
+description: "Drawing circles, urban sketching meetups, drink-and-draws, neurodivergent art collectives, and side-project communities in Vancouver — welcoming, mostly beginner-friendly, no talent required."
+date: 2026-07-09
+faq:
+  - q: "Where can I join an art or drawing group in Vancouver?"
+    a: "Vancouver has drawing circles, urban sketching meetups, casual drink-and-draws, and creative side-project communities, most of them beginner-friendly and social. The Vancouver Community Directory lists active creative and art groups on its creative & art page."
+  - q: "Do I need to be good at art to join?"
+    a: "No. Most groups are explicitly no-pressure and non-judgmental — cozy sketching in a café, slow drawing circles, and 'show up and make something' meetups welcome complete beginners. They're as much about community as technique."
+  - q: "Are there free or low-cost art meetups in Vancouver?"
+    a: "Yes. Many are free to attend beyond your own materials — urban sketching walks, café drawing meetups, and drink-and-draws where you just buy your own drink. It's one of the cheapest ways to meet creative people in the city."
+  - q: "How do I meet other creative people in Vancouver?"
+    a: "Join a recurring creative meetup — a weekly sketch club, a monthly talk, or a side-project community — and keep showing up. Making things alongside other people is one of the easiest, lowest-pressure ways to make friends here."
+---
+
+There's something disarming about making art next to strangers. Nobody's performing, everyone's a little vulnerable, and by the end of the session you've somehow made a friend and a bad drawing you're weirdly proud of. Vancouver has a deep bench of these groups — and almost none of them care whether you're any good.
+
+Here's where to draw, sketch, and build alongside other people, by vibe. Every group below is real and active, from [the directory's creative & art page](/creative-art/).
+
+## If you want cozy and low-pressure
+
+- **[Draw Around Vancouver](/creative-art/)** runs slow drawing circles and creative-flow workshops — tea, community, alcohol-free options. The gentlest possible entry point.
+- **Cozy Art Meetup** is relaxed sketching and chitchat in downtown cafés — no pressure, come make friends.
+- **The Artist's Way Vancouver** is a supportive discussion group for creative people who want encouragement more than critique.
+
+## If you like to sketch out in the world
+
+- **[Urban Sketchers Vancouver](/creative-art/)** meets outdoors to draw the city — "we show the world, one drawing at a time."
+- **Van Sketch Club** does Saturday-afternoon social sketching.
+- **Sketchup at East Van Brewing** is a casual drink-and-draw for when you want a beer with your pencil.
+
+## If you want your specific creative community
+
+- **Neurodivergent Artist Collective** — a space for neurodivergent artists, run by the Community Arts Council of Vancouver.
+- **Creative Pulse** and **Vancouver Creatives** — for connecting with other working creatives and talking shop.
+- **Atelier** — a community for working on side projects together: embroidery, coding, music, building — anything goes.
+- **CreativeMornings Vancouver** — free monthly morning talks that draw the whole creative scene into one room.
+
+## Making the most of it
+
+**You don't need to be good.** Every group above is built for showing up, not showing off. The point is the making and the company.
+
+**Bring the bare minimum and borrow the rest.** A pencil and a notebook is enough for most of these; regulars are generous with supplies and advice.
+
+**Go a few times.** Like everything in our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/), the magic is repetition — the same faces at the same café table until they're your people. Classes and studios are especially good for this because they run in multi-week cohorts.
+
+Want the full list, including studios, festivals, and photography workshops? [Browse every creative group](/creative-art/), or [add one](/submit/) you know about.
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/cycling-clubs-in-vancouver.md
+++ b/content/blog/cycling-clubs-in-vancouver.md
@@ -1,0 +1,53 @@
+---
+layout: post
+tags: post
+title: "Cycling clubs and group rides in Vancouver"
+description: "Road, gravel, and social cycling clubs in Vancouver — no-pressure community rides, women and 2SLGBTQIA+ groups, race teams, coffee rides, and clubs that have run since the 1970s."
+date: 2026-07-09
+faq:
+  - q: "How do I find a cycling club in Vancouver?"
+    a: "Pick by riding style: relaxed social clubs and coffee rides for community, road clubs for training and distance, gravel groups for off-pavement, and race teams for competition. The Vancouver Community Directory lists active cycling clubs across all of these."
+  - q: "Are there beginner-friendly cycling groups in Vancouver?"
+    a: "Yes — several social clubs are explicitly no-pressure, no-kit, no-drop, and welcome riders of any level. Inclusive Friday morning coffee rides and 'ride for fun' groups are the easiest way in."
+  - q: "Are there women's or 2SLGBTQIA+ cycling groups in Vancouver?"
+    a: "Yes. There are gravel and road groups focused on women, gender-diverse, and 2SLGBTQIA+ riders, plus inclusive community rides that welcome everyone regardless of pace or experience."
+  - q: "What's the best way to meet people cycling in Vancouver?"
+    a: "Join a group with a recurring ride — a weekly coffee ride or social club — and show up a few times. Group rides are repetition machines: same route, same time, same faces, which is how casual riders become friends."
+---
+
+Cycling in Vancouver is almost unfair — the seawall, the North Shore climbs, gravel an hour from downtown. What's harder to find is the *group*: people to ride with who match your pace and don't make you feel like you showed up to the wrong party. Good news — there's a club for every kind of rider here.
+
+Here's how to find yours, by riding style. Every club below is real and active, from [the directory's cycling page](/cycling/).
+
+## If you just want the community (no pressure)
+
+- **[Gruppetto](/cycling/)** says it best: "we're not a club — no fees, kits, or pressure." An inclusive community for road and gravel cyclists, riding for goals or just for fun.
+- **CoffeeOutside YVR** is an inclusive Friday-morning bike group — bring your coffee, that's the whole commitment.
+- **Out-n-About Cycling** runs volunteer-led social rides exploring Metro Vancouver at an adult, unhurried pace.
+
+## If you ride road and want distance or training
+
+- **[Lotus Cycling Club](/cycling/)** — road cycling with group rides, training, and workshops.
+- **The Last Drop Cycling Club** — road enthusiasts "for those who give it everything."
+- **Vancouver Bicycle Club** — touring and recreational riding, going strong since **1976**.
+- **Gastown Cycling Club** — a race team plus long-distance group rides (75–120km), March to October.
+
+## If you ride gravel — or want your specific crowd
+
+- **Gravel Buddies** is a gravel-riding social group focused on women, gender-diverse, and 2SLGBTQIA+ riders.
+- **Vancouver Velo Vets** — road cycling, mostly 50+ but all welcome.
+- **Tri-City Cycling Club** — for the Port Moody / Coquitlam / Port Coquitlam side.
+
+## Getting the most out of a group ride
+
+**Match the pace honestly.** Every club above lists its style — a "ride for fun" group beats getting shelled off the back of a race pace.
+
+**The coffee stop is the point.** Group rides bond over the mid-ride espresso, not the KOM. Show up for that part.
+
+**Go weekly, not once.** Like every good way to [make friends in Vancouver](/blog/how-to-make-friends-in-vancouver/), cycling clubs work by repetition — the same Friday ride, the same faces, until they're your people.
+
+Want the full roster, including race teams and touring clubs? [Browse every cycling group](/cycling/), or [add one](/submit/) you know about. Prefer trails to tarmac? There's a [hiking guide](/blog/hiking-clubs-in-vancouver/) too.
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/hiking-clubs-in-vancouver.md
+++ b/content/blog/hiking-clubs-in-vancouver.md
@@ -1,0 +1,57 @@
+---
+layout: post
+tags: post
+title: "Hiking clubs and groups in Vancouver (for every pace)"
+description: "Beginner-friendly, social, and serious hiking clubs in Vancouver — free adventure crews, transit-accessible hikes, slow-paced groups, seniors' clubs, and century-old mountaineering societies."
+date: 2026-07-09
+faq:
+  - q: "How do I find a hiking group in Vancouver?"
+    a: "Start with your pace and goals: free social adventure clubs and beginner groups for newcomers, established clubs like the BC Mountaineering Club or Alpine Club of Canada for serious trips, and transit-accessible groups if you don't have a car. The Vancouver Community Directory lists active hiking groups across all of these."
+  - q: "Are there beginner hiking groups in Vancouver?"
+    a: "Yes — several groups are built specifically for beginners, plus slow-paced clubs with a no-drop, we'll-wait-for-you policy. They stick to easier trails and welcome people who've never hiked here before."
+  - q: "How can I go hiking in Vancouver without a car?"
+    a: "Look for transit-accessible hiking groups — some organize hikes reachable entirely by bus and SkyTrain, so you can join without driving. Many meet at a transit hub before heading to the trail together."
+  - q: "What's the best way to meet people while hiking in Vancouver?"
+    a: "Join a group that hikes on a regular schedule and go a few times. Free adventure clubs like Y Adventure Kommunity and weekly meetup groups are designed around making friends on the trail, not just covering distance."
+---
+
+Vancouver is one of the great hiking cities on earth — the mountains start where the streets end. But going alone gets lonely, and the trailheads can be intimidating if you're new. The fix is a group: someone who knows the trail, a ride to share, and a reason to actually go on Saturday instead of staying in.
+
+Here's how to find a hiking group that fits your pace and your goals. Every club below is a real, active one from [the directory's hiking & outdoors page](/hiking-outdoors/).
+
+## If you're new to hiking (or new to Vancouver)
+
+- **[Y Adventure Kommunity (YAK)](/hiking-outdoors/)** is a *free* adventure club — hiking, paddle boarding, biking, bouldering, camping — built explicitly around making friends through the outdoors. The best possible starting point.
+- **Beginner Hiking Groups** stick to easy, low-pressure trails and expect that you've never done this before.
+- **Slow Hikers Vancouver** is for anyone who takes twice the suggested time — their whole motto is "we'll wait for you." No rushing, no getting dropped.
+- **Let's Adventure Vancouver** runs weekly outdoor stranger meetups (hikes, cold plunges, paddling) that are warm to first-timers.
+
+## If you don't have a car
+
+Getting to a trailhead is half the battle. Some groups solve it for you: look for the **transit-accessible** hiking groups on the [hiking page](/hiking-outdoors/) that organize hikes reachable entirely by bus and SkyTrain, meeting at a station before heading out together. **Wanderung** — a 3,600-person subscriber-organized adventure list — is also great for finding car-shares to farther trailheads.
+
+## If you want an established club
+
+- **[BC Mountaineering Club](/hiking-outdoors/)** has been running serious outdoor trips since **1907** — an experienced community for challenging hikes and climbs.
+- **Alpine Club of Canada – Vancouver** brings 1,500+ members, trips, courses, and backcountry hut access.
+- **North Shore / North Van** clubs are established, insured, and cover hiking, snowshoeing, backpacking, and more year-round.
+
+## If you want your specific crowd
+
+- **Golden Age Hiking Club** — social, moderate-pace hikes for active seniors (55+).
+- **Out and About Vancouver** — gay men and friends enjoying nature together.
+- **BC Kids Hiking Club** — family hiking for parents with kids (ages 3+), building trail-savvy little ones.
+
+## A few trail notes
+
+**Go with a group three times before you judge it.** The first hike you're the new person; by the third you're the one welcoming someone else. That repetition is the whole secret to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/), on the trail or off.
+
+**Say yes to the post-hike food.** The friendships form at the taco stand afterward, not on the switchbacks.
+
+**Match the group to your honest fitness, not your aspirational one.** Every club above lists its difficulty; a "we'll wait for you" group beats getting dropped on a summit push.
+
+Want the full list, including snowshoe and backpacking crews? [Browse every hiking group](/hiking-outdoors/), or if you run one, [add it to the directory](/submit/). Prefer two wheels? There's a [cycling guide](/blog/cycling-clubs-in-vancouver/) too.
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*


### PR DESCRIPTION
More SEO surface on the next tier of high-traffic categories, continuing the proven guide pattern — each funnels into its category page (and its sponsor slot).

- **Hiking clubs and groups in Vancouver** → `/hiking-outdoors/` (by pace: beginner, car-free, established clubs, seniors/family/LGBTQ+)
- **Cycling clubs and group rides in Vancouver** → `/cycling/` (by style: social, road, gravel, race)
- **Creative and art groups in Vancouver** → `/creative-art/` (drawing circles, urban sketching, drink-and-draws, side-project communities)

Each has Article + FAQPage schema, warm on-brand voice, and internal links to the real groups and the other guides. All internal links verified; auto-appear in sitemap + blog index.

That brings the guide library to 8, covering the site's highest-traffic themes — the flywheel that grows the traffic every sponsor slot is priced against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_