### PR TITLE
Add 3 more SEO guides: board games, pub trivia, sauna & cold plunge

### DIFF
--- a/content/blog/board-game-cafes-and-groups-in-vancouver.md
+++ b/content/blog/board-game-cafes-and-groups-in-vancouver.md
@@ -1,0 +1,50 @@
+---
+layout: post
+tags: post
+title: "Board game cafés and groups in Vancouver"
+description: "Where to play board games and meet people in Vancouver — no-play-fee game cafés, downtown meetups, social deduction nights, and inclusive 2SLGBTQIA+ gaming groups. Drop in, no experience needed."
+date: 2026-07-09
+faq:
+  - q: "Where can I play board games in Vancouver?"
+    a: "Vancouver has board game cafés with big game libraries (some with no play fee — you just order food and drinks) plus regular meetup groups that gather downtown and on the North Shore. The Vancouver Community Directory lists active board game cafés and groups on its board games page."
+  - q: "Do I need to bring my own games or know how to play?"
+    a: "No. Cafés provide huge game libraries and staff who'll teach you, and meetup groups bring modern games and welcome complete beginners. Board games are one of the lowest-pressure ways to meet people — the game gives you something to do and talk about."
+  - q: "Are there board game cafés with no play fee in Vancouver?"
+    a: "Yes — at least one Vancouver board game café has no cover charge to play; you just order food or drinks and play from their library. Others charge a small fee that includes access to hundreds of games."
+  - q: "How do I meet people through board games in Vancouver?"
+    a: "Join a recurring board game meetup or become a regular at a game café night. Showing up to the same weekly or biweekly game night is how strangers around a table turn into a friend group."
+---
+
+Board games might be the single lowest-stakes way to meet people in Vancouver. There's no awkward "so what do you do" — there's a game to focus on, rules to figure out together, and a built-in reason to talk to strangers for two hours. By the time someone's betrayed you in a social deduction round, you're basically friends.
+
+Here's where to play, whether you want a café with a wall of games or a group that meets on a schedule. Everything below is real and active, from [the directory's board games page](/board-games/).
+
+## Cafés — just show up and play
+
+- **[Pizzeria Ludica](/board-games/)** is the easy answer: a board game café with **no play fee** — order food or drinks and pull from a huge library.
+- **Hideout Café** runs biweekly board game meetups.
+- **Mench Café** is a board gaming and cyber café rolled into one.
+- **Boardwalk Café and Games** (in Abbotsford) has 600+ tabletop games — worth the drive if you're a serious collector.
+
+Cafés are the best entry point because you can go alone, get a game taught to you, and leave having met the table next to you.
+
+## Groups — meet the regulars
+
+- **[Vancouver Board Games](/board-games/)** is the largest regularly-meeting group downtown — the default if you want reliable weekly play.
+- **Good Game – North Vancouver** brings modern games and an inclusive, friendly vibe for the North Shore crowd.
+- **Vancouver Social Deduction Gamers** is for Mafia-style hidden-role games, if you like your board games with a side of paranoia.
+- **Vancouver Gaymers** creates safer spaces for 2SLGBTQIA+ people and allies to meet and play — one of the warmest gaming communities in the city.
+
+## Tips for showing up
+
+**Go alone.** A table always has room for one more, and a solo newcomer gets folded in fast — it's less awkward than arriving with a friend and sticking to them.
+
+**Say yes to a game you don't know.** Learning the rules together is the fastest bonding shortcut there is.
+
+**Become a regular.** Like everything in our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/), the magic is repetition — the same weekly game night until those people are your people.
+
+Want the full list of cafés and groups? [Browse the board games page](/board-games/), or [add one](/submit/) you know about. In it for the social side? A [pub trivia night](/blog/pub-trivia-nights-in-vancouver/) scratches the same itch.
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/pub-trivia-nights-in-vancouver.md
+++ b/content/blog/pub-trivia-nights-in-vancouver.md
@@ -1,0 +1,48 @@
+---
+layout: post
+tags: post
+title: "The best pub trivia nights in Vancouver"
+description: "Where to find pub trivia in Vancouver — weekly quiz nights across the city, free geeky trivia, Saturday options, and burger-and-beer deals. Grab a team (or show up solo) and play."
+date: 2026-07-09
+faq:
+  - q: "Where is there pub trivia in Vancouver?"
+    a: "Vancouver has weekly pub trivia nights across the city — from theatrical hosted quizzes to free geeky-topic nights and Saturday-only options. The Vancouver Community Directory lists active trivia nights on its pub trivia page."
+  - q: "Can I go to trivia night alone in Vancouver?"
+    a: "Yes — teams almost always need an extra brain, and hosts are used to folding in solo players. Turning up alone and joining a short-handed team is a low-pressure, reliable way to meet people."
+  - q: "Is there free pub trivia in Vancouver?"
+    a: "Yes, several trivia nights are free to play (some with prizes and food-and-drink specials). Free geeky-topic trivia covering film, TV, video games, and science is a favourite for teams of friends."
+  - q: "Is there trivia on Saturdays in Vancouver?"
+    a: "Most trivia runs on weeknights, but there is at least one Saturday-night option in Vancouver if the weekend suits you better."
+---
+
+Pub trivia is a small miracle of a social format. You get a reason to be somewhere, a team to belong to, two hours of low-stakes competition, and the specific joy of one person at the table inexplicably knowing every capital city in West Africa. It's also one of the easiest ways to meet people in Vancouver — teams are always looking for one more brain.
+
+Here's where to play across the city. Every listing below is real and active, from [the directory's pub trivia page](/pub-trivia/).
+
+## The regular circuit
+
+- **[IQ 2000 Trivia](/pub-trivia/)** is Vancouver's premier pub trivia host — theatrical, funny, and running nights across multiple venues.
+- **Vancouver Trivia Party** does quiz nights plus fundraisers and corporate events.
+- **The Butcher & Bullock Trivia** pairs the quiz with burger-and-beer specials (a $16 burger & beer, $5 Jameson) — downtown and dependable.
+
+## Free and niche
+
+- **Amazing Brentwood Tuesday Trivia** is **free**, covers geeky topics (film, TV, video games, science), and takes teams up to six — perfect for a low-cost weeknight out.
+
+## For the weekend crowd
+
+- **East Side Craft House Saturday Trivia** is the rare **Saturday-night** option, if weeknights don't work for you.
+
+## How to actually use trivia to meet people
+
+**Show up solo and ask to join a team.** Hosts do this all the time; a table short a player will happily adopt you. It's the least awkward "can I sit here?" in the city.
+
+**Pick a night and make it a ritual.** The friendships form when you're the *regulars* — same pub, same night, same rivalry with the team by the dartboard. That repetition is the whole trick, the same one behind our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/).
+
+**Lean into your one weird specialty.** Everybody's the hero of some category eventually. Yours is coming.
+
+Want the full schedule of trivia nights? [Browse the pub trivia page](/pub-trivia/), or [add one](/submit/) you know about. Prefer games with pieces? Try a [board game café or group](/blog/board-game-cafes-and-groups-in-vancouver/).
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*

--- a/content/blog/sauna-and-cold-plunge-in-vancouver.md
+++ b/content/blog/sauna-and-cold-plunge-in-vancouver.md
@@ -1,0 +1,55 @@
+---
+layout: post
+tags: post
+title: "Sauna and cold plunge in Vancouver (community heat and cold)"
+description: "Where to sauna and cold plunge in Vancouver — wood-fired mobile saunas, free community ocean plunges, Nordic spas, and sauna-plus-run clubs. Find the hot-and-cold ritual and the people who love it."
+date: 2026-07-09
+faq:
+  - q: "Where can I cold plunge in Vancouver?"
+    a: "Vancouver has free, community-led ocean and lake cold plunge groups, plus Nordic spas and sauna clubs with ice baths. The Vancouver Community Directory lists active sauna and cold plunge communities on its sauna & cold plunge page."
+  - q: "Is there free cold plunging in Vancouver?"
+    a: "Yes — community-led groups organize free outdoor ocean and lake plunges. It costs nothing but nerve, and going with a group is safer and far more fun than plunging alone."
+  - q: "Where are the saunas in Vancouver?"
+    a: "Options range from mobile wood-fired saunas and community sauna clubs to full Nordic spas with ice baths and tea lounges. Some pair sauna sessions with group runs or social 'open haus' rituals."
+  - q: "Is the sauna and cold plunge scene social in Vancouver?"
+    a: "Very. Much of it is built explicitly around community — shared hot-and-cold rituals, social sauna nights, and run-plus-sauna clubs. It's become one of the city's most connective wellness scenes."
+---
+
+Something clicked in Vancouver over the last few years: the hot-and-cold ritual went from a fringe habit to a full-blown community. Turns out that gasping your way out of the ocean in January, then thawing in a wood-fired sauna with a circle of strangers, is a shockingly good way to make friends. Shared mild suffering bonds people fast.
+
+Here's where to find the heat, the cold, and the community, from [the directory's sauna & cold plunge page](/sauna-cold-plunge/).
+
+## Free and community-led
+
+- **[Cold Plunge Vancouver](/sauna-cold-plunge/)** organizes free, outdoor, community-led ocean and lake plunges. No membership, no cost — just show up and get in. Going with a group is both safer and far more fun than doing it solo.
+
+## Saunas built around community
+
+- **The Good Sauna** is a mobile, outdoor wood-fired sauna whose whole mission is to "cultivate special meeting places and foster meaningful relationships."
+- **AetherHaus** runs Eastern-European-inspired sauna and cold plunge, with Silent and Social "Open Haus" nights and Aufguss rituals.
+- **Gatherwell** does outdoor sauna and cold plunges centred on "meaningful connection through the shared ritual of hot and cold."
+- **Tality Wellness** is a sauna club with community and private sessions, patio parties, and community runs.
+
+## Move first, then thaw
+
+- **Tality Community Runs + Sauna** pairs group runs with a sauna session afterward — fitness plus thermal recovery plus built-in company. A great two-birds way to meet the running *and* sauna crowds at once.
+
+## Full Nordic spas
+
+- **[Kolm Kontrast Nordic Spa](/sauna-cold-plunge/)** offers self-guided sauna, ice baths, and a tea lounge.
+- **Circle Wellness WellPod** is a private, intimate thermal spa with a cedar tub and cold plunge.
+- **Scandinave Spa Whistler** is the day-trip destination — Nordic baths with a strict silence policy, about two hours from the city.
+
+## Getting into it (literally)
+
+**Start with a community plunge, not a solo one.** The group makes the cold survivable and the whole thing social — you'll leave with numb toes and a couple of new numbers.
+
+**The warm-up chat is the point.** The friendships form in the sauna between rounds, not mid-plunge when nobody can speak.
+
+**Go back.** Like everything in our guide to [making friends in Vancouver](/blog/how-to-make-friends-in-vancouver/), it's the regulars who become your people — and few crowds are as tight-knit as the ones who freeze together on purpose.
+
+Want the full list of saunas, spas, and plunge groups? [Browse the sauna & cold plunge page](/sauna-cold-plunge/), or [add one](/submit/) you know about.
+
+---
+
+*Part of the [Vancouver Community Directory](/) — a free, community-built list of 250+ groups, clubs, and meetups across the city.*


### PR DESCRIPTION
Final SEO batch — three more guides on high-traffic categories that also have paying-business potential (game cafés, trivia venues, Nordic spas), so they grow traffic *and* feed sponsor slots.

- **Board game cafés and groups in Vancouver** → `/board-games/`
- **The best pub trivia nights in Vancouver** → `/pub-trivia/`
- **Sauna and cold plunge in Vancouver** → `/sauna-cold-plunge/`

Each has Article + FAQPage schema, warm on-brand voice, real-group references, and cross-links to the other guides. All internal links verified; auto-appear in sitemap + blog index.

That brings the guide library to **11**, covering the site's full high-traffic surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_