### PR TITLE
Trigger submit-worker deploy from main

### DIFF
--- a/workers/submit/index.js
+++ b/workers/submit/index.js
@@ -1,4 +1,5 @@
 // Cloudflare Worker for community submissions & edits -> GitHub Pull Requests
+// Deploys from main (Cloudflare Workers git integration).
 
 import {
   formatSubmissionEntry,


### PR DESCRIPTION
The hardened submission formatter (from #135) is already on `main`; this adds a one-line comment to `workers/submit/index.js` so a merge to `main` fires the Cloudflare Workers git-integration deploy of the submit worker. No behaviour change — the 21 formatter tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmvLkcs6NXWM1Y8NZodwv)_